### PR TITLE
CMake: Re-enable building of guichan_irrlicht extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,19 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake liballegro4-dev libsdl1.2-dev libsdl-image1.2-dev
+        sudo apt-get install -y \
+          build-essential \
+          cmake \
+          liballegro4-dev \
+          libirrlicht-dev \
+          libsdl-image1.2-dev \
+          libsdl1.2-dev
     - name: Configure
       run: cmake -B build
     - name: Build
       run: cmake --build build
+    - name: Install
+      run: sudo cmake --install build
 
   build-macos:
     runs-on: macos-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,12 @@ if(ENABLE_IRRLICHT)
   install(FILES ${GUICHAN_IRRLICHT_HEADER} DESTINATION include/guichan/)
   install(FILES ${GUICHAN_IRRLICHT_HEADERS}
           DESTINATION include/guichan/irrlicht/)
+
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/guichan_irrlicht.pc.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/guichan_irrlicht.pc @ONLY)
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/guichan_irrlicht.pc
+          DESTINATION lib/pkgconfig)
 endif()
 
 # Export targets for downstream projects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,14 +117,12 @@ add_library(
   ${GUICHAN_SRC}
   ${GUICHAN_WIDGET_SRC})
 
-target_include_directories(${PROJECT_NAME} PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+target_include_directories(
+  ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+                         $<INSTALL_INTERFACE:include>)
 
-set_target_properties(
-  ${PROJECT_NAME}
-  PROPERTIES VERSION ${PROJECT_VERSION}
-             SOVERSION ${PROJECT_SOVERSION})
+set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION}
+                                                 SOVERSION ${PROJECT_SOVERSION})
 install(
   TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}Targets
@@ -138,10 +136,8 @@ install(FILES ${GUICHAN_WIDGET_HEADERS} DESTINATION include/guichan/widgets/)
 install(FILES ${GUICHAN_CONTRIB_WIDGET_HEADERS}
         DESTINATION include/guichan/contrib/widgets/)
 
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/guichan.pc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/guichan.pc
-  @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/guichan.pc.in
+               ${CMAKE_CURRENT_BINARY_DIR}/guichan.pc @ONLY)
 
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/guichan.pc
@@ -186,9 +182,8 @@ if(ENABLE_ALLEGRO)
   endif()
 
   set_target_properties(
-    ${PROJECT_NAME}_allegro
-    PROPERTIES VERSION ${PROJECT_VERSION}
-               SOVERSION ${PROJECT_SOVERSION})
+    ${PROJECT_NAME}_allegro PROPERTIES VERSION ${PROJECT_VERSION}
+                                       SOVERSION ${PROJECT_SOVERSION})
   install(
     TARGETS ${PROJECT_NAME}_allegro
     EXPORT ${PROJECT_NAME}Targets
@@ -201,14 +196,11 @@ if(ENABLE_ALLEGRO)
   install(FILES ${GUICHAN_ALLEGRO_CONTRIB_HEADERS}
           DESTINATION include/guichan/contrib/allegro/)
 
-  configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/guichan_allegro.pc.in
-    ${CMAKE_CURRENT_BINARY_DIR}/guichan_allegro.pc
-    @ONLY)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/guichan_allegro.pc.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/guichan_allegro.pc @ONLY)
 
-  install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/guichan_allegro.pc
-    DESTINATION lib/pkgconfig)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/guichan_allegro.pc
+          DESTINATION lib/pkgconfig)
 endif()
 
 # The Guichan OpenGL extension library
@@ -249,29 +241,26 @@ if(ENABLE_OPENGL)
   endif()
 
   set_target_properties(
-    ${PROJECT_NAME}_opengl
-    PROPERTIES VERSION ${PROJECT_VERSION}
-               SOVERSION ${PROJECT_SOVERSION})
+    ${PROJECT_NAME}_opengl PROPERTIES VERSION ${PROJECT_VERSION}
+                                      SOVERSION ${PROJECT_SOVERSION})
   install(
     TARGETS ${PROJECT_NAME}_opengl
     EXPORT ${PROJECT_NAME}Targets
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include)
+    INCLUDES
+    DESTINATION include)
   install(FILES ${GUICHAN_OPENGL_HEADER} DESTINATION include/guichan/)
   install(FILES ${GUICHAN_OPENGL_HEADERS} DESTINATION include/guichan/opengl/)
   install(FILES ${GUICHAN_OPENGL_CONTRIB_HEADERS}
           DESTINATION include/guichan/contrib/opengl/)
 
-  configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/guichan_opengl.pc.in
-    ${CMAKE_CURRENT_BINARY_DIR}/guichan_opengl.pc
-    @ONLY)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/guichan_opengl.pc.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/guichan_opengl.pc @ONLY)
 
-  install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/guichan_opengl.pc
-    DESTINATION lib/pkgconfig)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/guichan_opengl.pc
+          DESTINATION lib/pkgconfig)
 endif()
 
 # The Guichan SDL extension library
@@ -308,17 +297,16 @@ if(ENABLE_SDL)
     if(MINGW)
       target_link_libraries(
         ${PROJECT_NAME}_sdl PRIVATE ${MINGW32_LIBRARY} ${SDL_LIBRARY}
-        ${SDLIMAGE_LIBRARY} SDLmain)
+                                    ${SDLIMAGE_LIBRARY} SDLmain)
     else()
-      target_link_libraries(${PROJECT_NAME}_sdl PRIVATE ${SDL_LIBRARY}
-                            ${SDLIMAGE_LIBRARY} SDLmain)
+      target_link_libraries(${PROJECT_NAME}_sdl
+                            PRIVATE ${SDL_LIBRARY} ${SDLIMAGE_LIBRARY} SDLmain)
     endif()
   endif()
 
   set_target_properties(
-    ${PROJECT_NAME}_sdl
-    PROPERTIES VERSION ${PROJECT_VERSION}
-               SOVERSION ${PROJECT_SOVERSION})
+    ${PROJECT_NAME}_sdl PROPERTIES VERSION ${PROJECT_VERSION}
+                                   SOVERSION ${PROJECT_SOVERSION})
   install(
     TARGETS ${PROJECT_NAME}_sdl
     EXPORT ${PROJECT_NAME}Targets
@@ -331,14 +319,11 @@ if(ENABLE_SDL)
   install(FILES ${GUICHAN_SDL_CONTRIB_HEADERS}
           DESTINATION include/guichan/contrib/sdl/)
 
-  configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/guichan_sdl.pc.in
-    ${CMAKE_CURRENT_BINARY_DIR}/guichan_sdl.pc
-    @ONLY)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/guichan_sdl.pc.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/guichan_sdl.pc @ONLY)
 
-  install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/guichan_sdl.pc
-    DESTINATION lib/pkgconfig)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/guichan_sdl.pc
+          DESTINATION lib/pkgconfig)
 endif()
 
 if(ENABLE_IRRLICHT)
@@ -388,9 +373,10 @@ if(ENABLE_IRRLICHT)
 endif()
 
 # Export targets for downstream projects
-install(EXPORT ${PROJECT_NAME}Targets
-        FILE ${PROJECT_NAME}Targets.cmake
-        DESTINATION lib/cmake/${PROJECT_NAME})
+install(
+  EXPORT ${PROJECT_NAME}Targets
+  FILE ${PROJECT_NAME}Targets.cmake
+  DESTINATION lib/cmake/${PROJECT_NAME})
 
 message(STATUS "Guichan ${PROJECT_VERSION} has been configured successfully!")
 message(STATUS "Build configuration:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(Allegro)
 find_package(OpenGL)
 find_package(SDL)
 find_package(SDL_image)
+find_package(Irrlicht)
 
 # Set default values for options
 set(SDL_DEFAULT OFF)
@@ -31,6 +32,7 @@ endif()
 option(ENABLE_ALLEGRO "Enable the Guichan Allegro extension" ${ALLEGRO_FOUND})
 option(ENABLE_OPENGL "Enable the Guichan OpenGL extension" ${OPENGL_FOUND})
 option(ENABLE_SDL "Enable the Guichan SDL extension" ${SDL_DEFAULT})
+option(ENABLE_IRRLICHT "Enable the Guichan Irrlicht extension" ${IRRLICHT_FOUND})
 
 option(BUILD_GUICHAN_SHARED
        "Build the Guichan core library as a shared library." ON)
@@ -43,6 +45,9 @@ option(BUILD_GUICHAN_OPENGL_SHARED
 
 option(BUILD_GUICHAN_SDL_SHARED
        "Build the Guichan SDL extension library as a shared library." ON)
+
+option(BUILD_GUICHAN_IRRLICHT_SHARED
+       "Build the Guichan Irrlicht extension library as a shared library." ON)
 
 # The Guichan core library
 file(GLOB GUICHAN_HEADER include/guichan.hpp)
@@ -336,6 +341,52 @@ if(ENABLE_SDL)
     DESTINATION lib/pkgconfig)
 endif()
 
+if(ENABLE_IRRLICHT)
+  if(NOT IRRLICHT_FOUND)
+    message(FATAL_ERROR "Irrlicht extension was enabled but Irrlicht library was not found")
+  endif()
+
+  # The Guichan Irrlicht extension source
+  file(GLOB GUICHAN_IRRLICHT_HEADER include/guichan/irrlicht.hpp)
+  file(GLOB GUICHAN_IRRLICHT_HEADERS include/guichan/irrlicht/*.hpp)
+  file(GLOB GUICHAN_IRRLICHT_SRC src/irrlicht/*.cpp)
+
+  # Grouping of the source for nicer display in IDEs such as Visual Studio
+  source_group(src/guichan FILES ${GUICHAN_IRRLICHT_HEADER})
+  source_group(src/guichan/irrlicht FILES ${GUICHAN_IRRLICHT_HEADERS}
+                                          ${GUICHAN_IRRLICHT_SRC})
+
+  if(BUILD_GUICHAN_IRRLICHT_SHARED)
+    set(GUICHAN_IRRLICHT_LIBRARY_TYPE SHARED)
+  else()
+    set(GUICHAN_IRRLICHT_LIBRARY_TYPE STATIC)
+  endif()
+
+  add_library(
+    ${PROJECT_NAME}_irrlicht
+    ${GUICHAN_IRRLICHT_LIBRARY_TYPE} ${GUICHAN_IRRLICHT_HEADER}
+    ${GUICHAN_IRRLICHT_HEADERS} ${GUICHAN_IRRLICHT_SRC})
+
+  target_include_directories(${PROJECT_NAME}_irrlicht PRIVATE ${IRRLICHT_INCLUDE_DIR})
+  target_link_libraries(${PROJECT_NAME}_irrlicht PRIVATE ${PROJECT_NAME})
+  if(WIN32)
+    target_link_libraries(${PROJECT_NAME}_irrlicht ${IRRLICHT_LIBRARY})
+  endif()
+  set_target_properties(
+    ${PROJECT_NAME}_irrlicht PROPERTIES VERSION ${PROJECT_VERSION}
+                                        SOVERSION ${PROJECT_SOVERSION})
+  install(
+    TARGETS ${PROJECT_NAME}_irrlicht
+    EXPORT ${PROJECT_NAME}Targets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include)
+  install(FILES ${GUICHAN_IRRLICHT_HEADER} DESTINATION include/guichan/)
+  install(FILES ${GUICHAN_IRRLICHT_HEADERS}
+          DESTINATION include/guichan/irrlicht/)
+endif()
+
 # Export targets for downstream projects
 install(EXPORT ${PROJECT_NAME}Targets
         FILE ${PROJECT_NAME}Targets.cmake
@@ -349,6 +400,7 @@ message(STATUS "  Extensions:")
 message(STATUS "    Allegro:        ${ENABLE_ALLEGRO}")
 message(STATUS "    OpenGL:         ${ENABLE_OPENGL}")
 message(STATUS "    SDL:            ${ENABLE_SDL}")
+message(STATUS "    Irrlicht:       ${ENABLE_IRRLICHT}")
 message(STATUS "")
 message(STATUS "  Library types:")
 message(STATUS "    Core library:   ${GUICHAN_LIBRARY_TYPE}")
@@ -360,5 +412,8 @@ if(ENABLE_OPENGL AND OPENGL_FOUND)
 endif()
 if(ENABLE_SDL AND SDL_FOUND AND SDLIMAGE_FOUND)
   message(STATUS "    SDL:            ${GUICHAN_SDL_LIBRARY_TYPE}")
+endif()
+if(ENABLE_IRRLICHT AND IRRLICHT_FOUND)
+  message(STATUS "    Irrlicht:       ${GUICHAN_IRRLICHT_LIBRARY_TYPE}")
 endif()
 message(STATUS "")

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,8 @@ pkgconfig_DATA = guichan.pc
 
 EXTRA_DIST = guichan.pc.in \
              guichan_allegro.pc.in \
+             guichan_irrlicht.pc.in \
              guichan_opengl.pc.in \
              guichan_sdl.pc.in \
              CMakeLists.txt \
              CMake/Modules/FindAllegro.cmake
-

--- a/guichan_irrlicht.pc.in
+++ b/guichan_irrlicht.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: guichan_irrlicht
+Description: Irrlicht extension for the Guichan GUI library
+Version: @PROJECT_VERSION@
+Requires: guichan
+Libs: -L${libdir} -lguichan_irrlicht
+Cflags: -I${includedir}


### PR DESCRIPTION
This change re-applies f54148e4ff4fdbb931941ad868b6b62b30b3464c, which was lost in the 0.8 merge in 8b4f210c46e5624cf43d5d3db307bd43b0743ecc.

It also adds the installation of pkg-config files for the Irrlicht extension, as done for the other extension libraries.