### PR TITLE
Make Widget::getChildrenArea() default to the whole widget

### DIFF
--- a/include/guichan/widget.hpp
+++ b/include/guichan/widget.hpp
@@ -903,11 +903,17 @@ namespace gcn
 
         /**
          * Gets the area of the widget occupied by the widget's children.
-         * By default this method returns an empty rectangle as not all
-         * widgets are containers. If you want to make a container this
-         * method should return the area where the children resides. This
-         * method is used when drawing children of a widget when computing
-         * clip rectangles for the children.
+         * By default this method returns the whole area of the widget, so
+         * that any widget can act as a container without further ado. A
+         * widget that wants to confine its children to a smaller area, for
+         * instance to leave room for a frame or a title bar, should override
+         * this method. This method is used when drawing children of a widget
+         * when computing clip rectangles for the children.
+         *
+         * NOTE: Children outside of the children area are neither drawn nor
+         *       considered when looking up the widget under the mouse, so a
+         *       widget that returns an empty rectangle here will appear to
+         *       have no children at all.
          *
          * NOTE: The returned rectangle should be relative to the widget,
          *       i.e a rectangle with x and y coordinate (0,0) and with

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -649,7 +649,7 @@ namespace gcn
 
     Rectangle Widget::getChildrenArea()
     {
-        return Rectangle(0, 0, 0, 0);
+        return Rectangle(0, 0, getWidth(), getHeight());
     }
 
     FocusHandler* Widget::_getInternalFocusHandler()


### PR DESCRIPTION
Merging `BasicContainer` into `Widget` changed the default `getChildrenArea()` from the widget's whole area to an empty rectangle. Children outside the children area are neither drawn nor hit-tested, so `TabbedArea` and `Tab`, which both moved from `BasicContainer` to `Widget` without gaining an override, silently stopped showing their tab strip, content and captions.

Restoring the old default fixes both, and means any widget can act as a container without an extra override. `Container`, `Window`, `ScrollArea` and `DropDown` already override the method where they need a narrower area, so they are unaffected.

The empty default does not seem like a deliberate choice for the merged class: it dates from ea4d214 (2006), when a plain `Widget` genuinely could not have children, and both the body and the doc comment have been unchanged since. It is also not a performance trade-off, since `_draw()` pushes the clip area either way and the children loop is empty for a leaf widget.

Verified by building and running against the library: before, a `TabbedArea` with one tab reports a `0x0` children area and `getWidgetAt(10, 5) == NULL`, and a `Tab` sized 48x16 likewise. After, they report `200x100` and `48x16`, and `getWidgetAt` returns the child. `DropDown`'s deliberate empty-when-folded override still behaves as before.
