### PR TITLE
Fix child visibility test in Widget::_draw

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -971,13 +971,18 @@ namespace gcn
         const Rectangle& childrenArea = getChildrenArea();
         graphics->pushClipArea(childrenArea);
 
+        // Child dimensions are relative to the children area, so compare
+        // them against the area placed at the origin rather than against
+        // the children area in this widget's own coordinates.
+        const Rectangle visibleArea(0, 0, childrenArea.width, childrenArea.height);
+
         std::list<Widget*>::const_iterator iter;
         for (iter = mChildren.begin(); iter != mChildren.end(); iter++)
         {
             Widget* widget = (*iter);
-            // Only draw a widget if it's visible and if it visible
+            // Only draw a widget if it's visible and if it is visible
             // inside the children area.
-            if (widget->isVisible() && childrenArea.isIntersecting(widget->getDimension()))
+            if (widget->isVisible() && visibleArea.isIntersecting(widget->getDimension()))
                 widget->_draw(graphics);
         }
 


### PR DESCRIPTION
`Widget::_draw()` only draws a child when it intersects `getChildrenArea()`. That rectangle is in the widget's own coordinates (for `gcn::Window` it starts at the title bar height), while child dimensions are relative to the origin of the children area. Comparing them directly skips children near the top edge that are shorter than that offset.

The test came in with 44fb97c (issue 89) as an optimization to skip children fully outside the children area. This keeps that, but compares against the area placed at the origin so both rectangles are in the same space.

This complements the NOTE added in #18 about children outside the children area not being drawn: with this fix, "outside" is measured correctly.
