### PR TITLE
Stop ScrollArea running its content's logic twice

### DIFF
--- a/src/widgets/scrollarea.cpp
+++ b/src/widgets/scrollarea.cpp
@@ -782,7 +782,6 @@ namespace gcn
         {
             getContent()->setPosition(-mHScroll + getContent()->getFrameSize(),
                                       -mVScroll + getContent()->getFrameSize());
-            getContent()->logic();
         }
     }
 


### PR DESCRIPTION
`Widget::_logic()` already runs `logic()` on every child, so the explicit `getContent()->logic()` call in `ScrollArea::logic()` ran the content's logic twice per frame. This removes the call; the content is still positioned in `ScrollArea::logic()` before its own logic runs. Same cleanup as the earlier removal of `TabbedArea::logic()`.

Audited the other `logic()` implementations (`ListBox`, `AdjustingContainer`, `Gui`) and found no other direct child `logic()` calls.