### PR TITLE
Reintroduce Widget::drawChildren as an overridable hook

### DIFF
--- a/include/guichan/widget.hpp
+++ b/include/guichan/widget.hpp
@@ -1034,6 +1034,23 @@ namespace gcn
 
     protected:
         /**
+         * Draws the children of the widget. Called by _draw after the
+         * widget's draw function has been called. The children area
+         * given by getChildrenArea is pushed as clip area and only
+         * visible children intersecting the children area are drawn.
+         *
+         * Subclasses that need to wrap the drawing of the children,
+         * for instance to apply an additional clip area, can overload
+         * this function. Overloaded functions should call the base
+         * implementation to have the children drawn.
+         *
+         * @param graphics A graphics object to draw with.
+         * @see draw, getChildrenArea
+         * @since 0.9.0
+         */
+        virtual void drawChildren(Graphics* graphics);
+
+        /**
          * Distributes an action event to all action listeners
          * of the widget.
          *

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -967,7 +967,12 @@ namespace gcn
 
         graphics->pushClipArea(mDimension);
         draw(graphics);
+        drawChildren(graphics);
+        graphics->popClipArea();
+    }
 
+    void Widget::drawChildren(Graphics* graphics)
+    {
         const Rectangle& childrenArea = getChildrenArea();
         graphics->pushClipArea(childrenArea);
 
@@ -981,7 +986,6 @@ namespace gcn
                 widget->_draw(graphics);
         }
 
-        graphics->popClipArea();
         graphics->popClipArea();
     }
 

--- a/src/widgets/dropdown.cpp
+++ b/src/widgets/dropdown.cpp
@@ -201,7 +201,6 @@ namespace gcn
                                      mFoldedUpHeight,
                                      getWidth(),
                                      getHeight() - mFoldedUpHeight);
-             //drawChildren(graphics);
          }
     }
 

--- a/src/widgets/tabbedarea.cpp
+++ b/src/widgets/tabbedarea.cpp
@@ -316,7 +316,6 @@ namespace gcn
                                mTabContainer->getHeight());
 
         }
-
     }
 
     void TabbedArea::adjustSize()

--- a/src/widgets/tabbedarea.cpp
+++ b/src/widgets/tabbedarea.cpp
@@ -317,7 +317,6 @@ namespace gcn
 
         }
 
-        //drawChildren(graphics);
     }
 
     void TabbedArea::adjustSize()

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -189,7 +189,6 @@ namespace gcn
                            d.x + d.width - 1,
                            d.y + d.height - 1);
 
-
         int textX;
         int textY;
 

--- a/src/widgets/window.cpp
+++ b/src/widgets/window.cpp
@@ -189,7 +189,6 @@ namespace gcn
                            d.x + d.width - 1,
                            d.y + d.height - 1);
 
-        //drawChildren(graphics);
 
         int textX;
         int textY;


### PR DESCRIPTION
Since `BasicContainer` was merged into `Widget`, the child drawing loop lives inline in `Widget::_draw`, so a subclass that wants to wrap child drawing has no hook. The Mana client needs this in its `ScrollArea` and `TabbedArea` (its `Graphics` disables clipping in `pushClipArea`, so it applies its own clip rectangle around the children) and had to copy the whole `_draw` body twice.

This moves the loop into a protected virtual `drawChildren(Graphics*)` that `_draw` calls after `draw`. Overriding subclasses call the base implementation to keep the default behaviour. The stale commented-out `drawChildren` calls in DropDown, TabbedArea and Window are dropped, since the hook is no longer meant to be called from `draw`.
