### PR TITLE
Detach a widget from its previous parent in Widget::add()

### DIFF
--- a/include/guichan/widget.hpp
+++ b/include/guichan/widget.hpp
@@ -1072,6 +1072,11 @@ namespace gcn
         /**
          * Adds a child to the widget.
          *
+         * A widget can only have one parent. If the widget already has a
+         * parent (this widget or another one), it is removed from that
+         * parent first. Adding a widget that is already a child of this
+         * widget therefore moves it to the end of the child list.
+         *
          * THIS METHOD IS NOT SAFE TO CALL INSIDE A WIDGETS LOGIC FUNCTION
          * INSIDE ANY LISTER FUNCTIONS!
          *

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -858,6 +858,12 @@ namespace gcn
 
     void Widget::add(Widget* widget)
     {
+        // A widget can only have one parent. Detach it from its current
+        // parent first (which may be this widget), so that mChildren never
+        // holds the same widget twice and no parent keeps a dangling pointer.
+        if (widget->getParent() != NULL)
+            widget->getParent()->remove(widget);
+
         mChildren.push_back(widget);
 
         if (mInternalFocusHandler == NULL)


### PR DESCRIPTION
`Widget::add()` appended the widget to `mChildren` and overwrote its parent pointer without checking whether it already had one. Adding a widget twice, or to two containers, left duplicate entries or a stale parent still listing the widget. In 0.8 this was harmless because `BasicContainer` registered a death listener on each child and removed all matching entries; since the merge into `Widget`, `remove()` erases only the first entry and the destructor only informs the current parent. The Mana client placed one `Spacer` in three layout cells and crashed on exit when the container deleted the same child twice.

`Widget::add()` now removes the widget from its current parent first, through the parent's virtual `remove()` so `Container` still distributes its `widgetRemoved` event. Adding a widget that is already a child moves it to the end of the child list. The behaviour is documented in the header.

Verified with a build (SDL/OpenGL/Allegro/Irrlicht disabled) and a standalone ASan check: add twice to one container, add to three containers, and destroy a container holding a widget added three times; no leaks or double frees, and the container ends up with no children.
