### PR TITLE
Make Text, TextField and TextBox UTF-8 aware

### DIFF
--- a/include/guichan/key.hpp
+++ b/include/guichan/key.hpp
@@ -63,10 +63,13 @@ namespace gcn
         Key(int value = 0);
 
         /**
-         * Checks if a key is a character.
+         * Checks if a key is a character, that is a value that can be
+         * inserted into text. This is the case for printable ASCII
+         * (32 to 126), Tab, and every Unicode code point from 160 up to
+         * 0x10FFFF. Control characters and the special key values
+         * are not characters.
          *
-         * @return True if the key is a letter, number or whitespace,
-         *         false otherwise.
+         * @return True if the key is a character, false otherwise.
          */
         bool isCharacter() const;
 

--- a/include/guichan/text.hpp
+++ b/include/guichan/text.hpp
@@ -344,23 +344,46 @@ namespace gcn
         unsigned int getNumberOfRows() const;
 
         /**
-         * Gets the number of characters in the text.
+         * Gets the number of characters in the text. A character is a
+         * Unicode code point, so this is not the same as the length in
+         * bytes for UTF-8 content. Line feeds between rows are counted
+         * as characters.
          *
          * @return The number of characters in the text.
+         * @see getNumberOfColumns
          * @since 0.9.0
          */
         unsigned int getNumberOfCharacters() const;
 
         /**
          * Gets the number of characters in a certain row in the text.
-         * If the row does not exist, zero will be returned.
+         * A character is a Unicode code point, so this is not the same
+         * as the length in bytes. Use getNumberOfColumns for the byte
+         * length, which is what caret columns are measured in. If the
+         * row does not exist, zero will be returned.
          *
          * @param row The row to get the number of characters in.
          * @return The number of characters in a certain row, or zero
          *         if the row does not exist.
+         * @see getNumberOfColumns
          * @since 0.9.0
          */
         unsigned int getNumberOfCharacters(unsigned int row) const;
+
+        /**
+         * Gets the number of columns in a certain row in the text, that
+         * is the length of the row in bytes. Caret columns are byte
+         * offsets, so this is the column right after the last character
+         * of the row. Use getNumberOfCharacters to count characters
+         * instead. If the row does not exist, zero will be returned.
+         *
+         * @param row The row to get the number of columns in.
+         * @return The number of columns in a certain row, or zero
+         *         if the row does not exist.
+         * @see getNumberOfCharacters
+         * @since 0.9.0
+         */
+        unsigned int getNumberOfColumns(unsigned int row) const;
 
         /**
          * Gets the column where the UTF-8 character before a given column

--- a/include/guichan/text.hpp
+++ b/include/guichan/text.hpp
@@ -55,9 +55,15 @@ namespace gcn
     class Font;
 
     /**
-     * A utility class to ease working with text in widgets such as 
+     * A utility class to ease working with text in widgets such as
      * TextBox and TextField. The class wraps common text operations
      * such as inserting and deleting text.
+     *
+     * The content is expected to be UTF-8 encoded. Caret positions and
+     * columns are byte offsets into the content, so they can be used to
+     * index the rows directly, but all editing and caret movement works
+     * on whole UTF-8 sequences and the caret is always kept at the start
+     * of a sequence.
      *
      * @since 0.9.0
      */
@@ -146,21 +152,34 @@ namespace gcn
         virtual std::string& getRow(unsigned int row);
 
         /**
-         * Inserts a character at the current caret position.
+         * Inserts a UTF-8 encoded string at the current caret position.
+         * Line feeds in the string split the current row. The caret is
+         * moved to the end of the inserted text.
          *
-         * @parameter character The character to insert.
+         * @param text The UTF-8 encoded text to insert.
+         * @since 0.9.0
+         */
+        virtual void insert(const std::string& text);
+
+        /**
+         * Inserts a character at the current caret position. The character
+         * is a Unicode code point which is UTF-8 encoded before insertion.
+         * Values outside of the range 0 to 0x10FFFF are ignored.
+         *
+         * @param character The Unicode code point to insert.
          * @since 0.9.0
          */
         virtual void insert(int character);
 
         /**
-         * Removes a given number of characters at starting
-         * at the current caret position. 
-         * 
-         * If the number of characters to remove is negative 
+         * Removes a given number of characters starting at the current
+         * caret position. A character is a whole UTF-8 sequence, so
+         * removing one character may remove several bytes.
+         *
+         * If the number of characters to remove is negative
          * characters will be removed left of the caret position.
          * If the number is positive characters will be removed
-         * right of the caret position. If a line feed is 
+         * right of the caret position. If a line feed is
          * removed the row with the line feed will be merged
          * with the row above the line feed.
          *
@@ -328,6 +347,31 @@ namespace gcn
          * @since 0.9.0
          */
         virtual unsigned int getNumberOfCharacters(unsigned int row) const;
+
+        /**
+         * Gets the column where the UTF-8 character before a given column
+         * starts. If the column is zero, zero is returned.
+         *
+         * @param row The content of the row.
+         * @param column The column to step back from.
+         * @return The column where the previous character starts.
+         * @since 0.9.0
+         */
+        static unsigned int getPreviousCharacterColumn(const std::string& row,
+                                                       unsigned int column);
+
+        /**
+         * Gets the column right after the UTF-8 character that starts at
+         * a given column. If the column is at the end of the row, the
+         * length of the row is returned.
+         *
+         * @param row The content of the row.
+         * @param column The column to step forward from.
+         * @return The column where the next character starts.
+         * @since 0.9.0
+         */
+        static unsigned int getNextCharacterColumn(const std::string& row,
+                                                   unsigned int column);
 
     protected:
 

--- a/include/guichan/text.hpp
+++ b/include/guichan/text.hpp
@@ -146,19 +146,6 @@ namespace gcn
         const std::string& getRow(unsigned int row) const;
 
         /**
-         * Gets a mutable reference to a row. Changing the row through
-         * this reference bypasses the caret handling, so callers have to
-         * restore a valid caret afterwards, for example by calling
-         * setCaretPosition with the current caret position.
-         *
-         * @param row The row to get the content of.
-         * @return The reference to a row.
-         * @throws Exception when no such row exists.
-         * @since 0.9.0
-         */
-        std::string& getRow(unsigned int row);
-
-        /**
          * Inserts a UTF-8 encoded string at the current caret position.
          * Line feeds in the string split the current row. The caret is
          * moved to the end of the inserted text.

--- a/include/guichan/text.hpp
+++ b/include/guichan/text.hpp
@@ -149,6 +149,19 @@ namespace gcn
          * @throws Exception when no such row exists.
          * @since 0.9.0
          */
+        virtual const std::string& getRow(unsigned int row) const;
+
+        /**
+         * Gets a mutable reference to a row. Changing the row through
+         * this reference bypasses the caret handling, so callers have to
+         * restore a valid caret afterwards, for example by calling
+         * setCaretPosition with the current caret position.
+         *
+         * @param row The row to get the content of.
+         * @return The reference to a row.
+         * @throws Exception when no such row exists.
+         * @since 0.9.0
+         */
         virtual std::string& getRow(unsigned int row);
 
         /**
@@ -198,7 +211,9 @@ namespace gcn
 
         /**
          * Sets the caret position. The position will be
-         * clamp to the dimension of the content.
+         * clamp to the dimension of the content. If the position
+         * lies inside of a UTF-8 sequence the caret is moved back
+         * to the start of that sequence.
          *
          * @param position The position of the caret.
          * @since 0.9.0
@@ -234,7 +249,9 @@ namespace gcn
 
         /**
          * Sets the column the caret should be in. The column
-         * will be clamp to the current row.
+         * will be clamp to the current row. If the column lies
+         * inside of a UTF-8 sequence the caret is moved back to
+         * the start of that sequence.
          *
          * @param column The column the caret should be in.
          * @since 0.9.0
@@ -254,6 +271,22 @@ namespace gcn
          * @since 0.9.0
          */
         virtual void setCaretRow(int row);
+
+        /**
+         * Moves the caret one character to the left. At the start of
+         * a row the caret moves to the end of the row above.
+         *
+         * @since 0.9.0
+         */
+        virtual void moveCaretLeft();
+
+        /**
+         * Moves the caret one character to the right. At the end of
+         * a row the caret moves to the start of the row below.
+         *
+         * @since 0.9.0
+         */
+        virtual void moveCaretRight();
 
         /**
          * Gets the x coordinate of the caret in pixels given a font.

--- a/include/guichan/text.hpp
+++ b/include/guichan/text.hpp
@@ -84,19 +84,13 @@ namespace gcn
         Text(const std::string& content);
 
         /**
-         * Destructor.
-         * @since 0.9.0
-         */
-        virtual ~Text();
-
-        /**
          * Sets the content of the text. Will completely remove 
          * any previous text and reset the caret position.
          *
          * @param content The content of the text.
          * @since 0.9.0
          */
-        virtual void setContent(const std::string& text);
+        void setContent(const std::string& text);
 
         /**
          * Gets the content of the text.
@@ -104,7 +98,7 @@ namespace gcn
          * @return The content of the text.
          * @since 0.9.0
          */
-        virtual std::string getContent() const;
+        std::string getContent() const;
 
         /**
          * Sets the content of a row.
@@ -113,7 +107,7 @@ namespace gcn
          * @throws Exception when the row does not exist.
          * @since 0.9.0
          */
-        virtual void setRow(unsigned int row, const std::string& content);
+        void setRow(unsigned int row, const std::string& content);
 
         /**
          * Adds a row to the content. Calling this method will
@@ -122,7 +116,7 @@ namespace gcn
          * @param row The row to add.
          * @since 0.9.0
          */
-        virtual void addRow(const std::string& row);
+        void addRow(const std::string& row);
 
         /**
          * Inserts a row before the specified row position. Calling this method
@@ -131,7 +125,7 @@ namespace gcn
          * @param row The row to add.
          * @param position Inserts new row before this row.
          */
-        virtual void insertRow(const std::string& row, unsigned int position);
+        void insertRow(const std::string& row, unsigned int position);
 
         /**
          * Erases the given row. Calling this method will not change the current
@@ -139,7 +133,7 @@ namespace gcn
          *
          * @param row Row to be erased.
          */
-        virtual void eraseRow(unsigned int row);
+        void eraseRow(unsigned int row);
 
         /**
          * Gets a reference to a row.
@@ -149,7 +143,7 @@ namespace gcn
          * @throws Exception when no such row exists.
          * @since 0.9.0
          */
-        virtual const std::string& getRow(unsigned int row) const;
+        const std::string& getRow(unsigned int row) const;
 
         /**
          * Gets a mutable reference to a row. Changing the row through
@@ -162,7 +156,7 @@ namespace gcn
          * @throws Exception when no such row exists.
          * @since 0.9.0
          */
-        virtual std::string& getRow(unsigned int row);
+        std::string& getRow(unsigned int row);
 
         /**
          * Inserts a UTF-8 encoded string at the current caret position.
@@ -172,7 +166,7 @@ namespace gcn
          * @param text The UTF-8 encoded text to insert.
          * @since 0.9.0
          */
-        virtual void insert(const std::string& text);
+        void insert(const std::string& text);
 
         /**
          * Inserts a character at the current caret position. The character
@@ -182,7 +176,7 @@ namespace gcn
          * @param character The Unicode code point to insert.
          * @since 0.9.0
          */
-        virtual void insert(int character);
+        void insert(int character);
 
         /**
          * Removes a given number of characters starting at the current
@@ -199,7 +193,7 @@ namespace gcn
          * @param numberOfCharacters The number of characters to remove.
          * @since 0.9.0
          */
-        virtual void remove(int numberOfCharacters);
+        void remove(int numberOfCharacters);
 
         /**
          * Gets the caret position.
@@ -207,7 +201,7 @@ namespace gcn
          * @return The caret position.
          * @since 0.9.0
          */
-        virtual int getCaretPosition() const;
+        int getCaretPosition() const;
 
         /**
          * Sets the caret position. The position will be
@@ -218,7 +212,7 @@ namespace gcn
          * @param position The position of the caret.
          * @since 0.9.0
          */
-        virtual void setCaretPosition(int position);
+        void setCaretPosition(int position);
         
         /**
          * Sets the caret position given an x and y coordinate in pixels
@@ -229,7 +223,7 @@ namespace gcn
          * @param font The font to use when calculating the position.
          * @since 0.9.0
          */
-        virtual void setCaretPosition(int x, int y, Font* font);
+        void setCaretPosition(int x, int y, Font* font);
 
         /**
          * Gets the column the caret is currently in.
@@ -237,7 +231,7 @@ namespace gcn
          * @return The column the caret is currently in.
          * @since 0.9.0
          */
-        virtual int getCaretColumn() const;
+        int getCaretColumn() const;
 
         /**
          * Gets the row the caret is currently in.
@@ -245,7 +239,7 @@ namespace gcn
          * @return The row the caret is currently in.
          * @since 0.9.0
          */
-        virtual int getCaretRow() const;
+        int getCaretRow() const;
 
         /**
          * Sets the column the caret should be in. The column
@@ -256,7 +250,7 @@ namespace gcn
          * @param column The column the caret should be in.
          * @since 0.9.0
          */
-        virtual void setCaretColumn(int column);
+        void setCaretColumn(int column);
 
         /**
          * Sets the row the caret should be in. If the row lies o
@@ -270,7 +264,7 @@ namespace gcn
          * @param row The row the caret should be in.
          * @since 0.9.0
          */
-        virtual void setCaretRow(int row);
+        void setCaretRow(int row);
 
         /**
          * Moves the caret one character to the left. At the start of
@@ -278,7 +272,7 @@ namespace gcn
          *
          * @since 0.9.0
          */
-        virtual void moveCaretLeft();
+        void moveCaretLeft();
 
         /**
          * Moves the caret one character to the right. At the end of
@@ -286,7 +280,7 @@ namespace gcn
          *
          * @since 0.9.0
          */
-        virtual void moveCaretRight();
+        void moveCaretRight();
 
         /**
          * Gets the x coordinate of the caret in pixels given a font.
@@ -295,7 +289,7 @@ namespace gcn
          * @return The x coorinate of the caret in pixels.
          * @since 0.9.0
          */
-        virtual int getCaretX(Font* font) const;
+        int getCaretX(Font* font) const;
 
         /**
          * Gets the y coordinate of the caret in pixels given a font.
@@ -304,7 +298,7 @@ namespace gcn
          * @return The y coorinate of the caret in pixels.
          * @since 0.9.0
          */
-        virtual int getCaretY(Font* font) const;
+        int getCaretY(Font* font) const;
 
         /**
          * Gets the dimension in pixels of the text given a font. If there
@@ -314,7 +308,7 @@ namespace gcn
          * @return The dimension in pixels of the text given a font.
          * @since 0.9.0
          */
-        virtual Rectangle getDimension(Font* font) const;
+        Rectangle getDimension(Font* font) const;
 
         /**
          * Gets the caret dimension relative to this text.
@@ -325,7 +319,7 @@ namespace gcn
          * @return The dimension of the caret.
          * @since 0.9.0
          */
-        virtual Rectangle getCaretDimension(Font* font) const;
+        Rectangle getCaretDimension(Font* font) const;
 
         /**
          * Gets the width in pixels of a row. If the row is not
@@ -335,7 +329,7 @@ namespace gcn
          * @return The width in pixels of a row.
          * @since 0.9.0
          */ 
-        virtual int getWidth(int row, Font* font) const;
+        int getWidth(int row, Font* font) const;
 
         /**
          * Gets the maximum row the caret can be in.
@@ -343,7 +337,7 @@ namespace gcn
          * @return The maximum row the caret can be in.
          * @since 0.9.0
          */
-        virtual unsigned int getMaximumCaretRow() const;
+        unsigned int getMaximumCaretRow() const;
 
         /**
          * Gets the maximum column of a row the caret can be in.
@@ -352,7 +346,7 @@ namespace gcn
          * @return The maximum column of a row the caret can be in.
          * @since 0.9.0
          */
-        virtual unsigned int getMaximumCaretRow(unsigned int row) const;
+        unsigned int getMaximumCaretRow(unsigned int row) const;
 
         /**
          * Gets the number of rows in the text.
@@ -360,7 +354,7 @@ namespace gcn
          * @return The number of rows in the text.
          * @since 0.9.0
          */
-        virtual unsigned int getNumberOfRows() const;
+        unsigned int getNumberOfRows() const;
 
         /**
          * Gets the number of characters in the text.
@@ -368,7 +362,7 @@ namespace gcn
          * @return The number of characters in the text.
          * @since 0.9.0
          */
-        virtual unsigned int getNumberOfCharacters() const;
+        unsigned int getNumberOfCharacters() const;
 
         /**
          * Gets the number of characters in a certain row in the text.
@@ -379,7 +373,7 @@ namespace gcn
          *         if the row does not exist.
          * @since 0.9.0
          */
-        virtual unsigned int getNumberOfCharacters(unsigned int row) const;
+        unsigned int getNumberOfCharacters(unsigned int row) const;
 
         /**
          * Gets the column where the UTF-8 character before a given column

--- a/include/guichan/widgets/textbox.hpp
+++ b/include/guichan/widgets/textbox.hpp
@@ -200,6 +200,40 @@ namespace gcn
         void setEditable(bool editable);
 
         /**
+         * Inserts UTF-8 encoded text at the caret position and moves the
+         * caret to the end of the inserted text. Line feeds in the text
+         * start new rows. Does nothing if the text box is not editable.
+         *
+         * @param text The UTF-8 encoded text to insert.
+         * @see removeCharacters, isEditable
+         * @since 0.9.0
+         */
+        void insertText(const std::string& text);
+
+        /**
+         * Removes a number of characters at the caret position. A negative
+         * count removes characters left of the caret, a positive count
+         * removes characters right of the caret. A character is a whole
+         * UTF-8 sequence, and removing a line feed merges two rows. Does
+         * nothing if the text box is not editable.
+         *
+         * @param count The number of characters to remove.
+         * @see insertText, isEditable
+         * @since 0.9.0
+         */
+        void removeCharacters(int count);
+
+        /**
+         * Gets the text object holding the content and the caret of the
+         * text box. Useful for measuring the text or the caret with a
+         * font, for example when drawing a subclass.
+         *
+         * @return The text object of the text box.
+         * @since 0.9.0
+         */
+        const Text& getTextObject() const;
+
+        /**
          * Adds a row of text to the end of the text.
          *
          * @param row The row to add.

--- a/include/guichan/widgets/textbox.hpp
+++ b/include/guichan/widgets/textbox.hpp
@@ -51,12 +51,11 @@
 #include "guichan/keylistener.hpp"
 #include "guichan/mouselistener.hpp"
 #include "guichan/platform.hpp"
+#include "guichan/text.hpp"
 #include "guichan/widget.hpp"
 
 namespace gcn
 {
-    class Text;
-
     /**
      * An implementation of a text box where a user can enter text that contains of many lines.
      */
@@ -288,7 +287,7 @@ namespace gcn
         /**
          * Holds the text of the text box.
          */
-        Text* mText;
+        Text mText;
 
         /**
          * True if the text box is editable, false otherwise.

--- a/include/guichan/widgets/textbox.hpp
+++ b/include/guichan/widgets/textbox.hpp
@@ -224,16 +224,6 @@ namespace gcn
         void removeCharacters(int count);
 
         /**
-         * Gets the text object holding the content and the caret of the
-         * text box. Useful for measuring the text or the caret with a
-         * font, for example when drawing a subclass.
-         *
-         * @return The text object of the text box.
-         * @since 0.9.0
-         */
-        const Text& getTextObject() const;
-
-        /**
          * Adds a row of text to the end of the text.
          *
          * @param row The row to add.

--- a/include/guichan/widgets/textfield.hpp
+++ b/include/guichan/widgets/textfield.hpp
@@ -47,14 +47,13 @@
 #include "guichan/keylistener.hpp"
 #include "guichan/mouselistener.hpp"
 #include "guichan/platform.hpp"
+#include "guichan/text.hpp"
 #include "guichan/widget.hpp"
 
 #include <string>
 
 namespace gcn
 {
-    class Text;
-
     /**
      * An implementation of a text field where a user can enter a line of text.
      */
@@ -203,7 +202,7 @@ namespace gcn
         /**
          * Holds the text of the text field.
          */
-        Text* mText;
+        Text mText;
 
         /**
          * Holds the amount scrolled in x. If a user types more characters than

--- a/include/guichan/widgets/textfield.hpp
+++ b/include/guichan/widgets/textfield.hpp
@@ -188,6 +188,33 @@ namespace gcn
         virtual void drawCaret(Graphics* graphics, int x);
 
         /**
+         * Gets the text as it should be drawn. The default implementation
+         * returns the text of the text field. Overload this method to draw
+         * something else than the stored text, for example a password field
+         * that returns one asterisk per character.
+         *
+         * The caret is placed by counting characters, so the returned string
+         * has to contain one character per character of the stored text,
+         * but the characters may use a different number of bytes.
+         *
+         * @return The text to draw.
+         * @see getCaretX
+         * @since 0.9.0
+         */
+        virtual std::string getDisplayText() const;
+
+        /**
+         * Gets the x coordinate of the caret in pixels, measured in the
+         * text returned by getDisplayText and not taking the horizontal
+         * scrolling into account.
+         *
+         * @return The x coordinate of the caret in pixels.
+         * @see getDisplayText
+         * @since 0.9.0
+         */
+        int getCaretX() const;
+
+        /**
          * Scrolls the text horizontally so that the caret shows if needed.
          * The method is used any time a user types in the text field so the
          * caret always will be shown.

--- a/include/guichan/widgets/textfield.hpp
+++ b/include/guichan/widgets/textfield.hpp
@@ -161,16 +161,6 @@ namespace gcn
          */
         void removeCharacters(int count);
 
-        /**
-         * Gets the text object holding the content and the caret of the
-         * text field. Useful for measuring the text or the caret with a
-         * font, for example when drawing a subclass.
-         *
-         * @return The text object of the text field.
-         * @since 0.9.0
-         */
-        const Text& getTextObject() const;
-
 
         // Inherited from Widget
 

--- a/include/guichan/widgets/textfield.hpp
+++ b/include/guichan/widgets/textfield.hpp
@@ -138,6 +138,39 @@ namespace gcn
          */
         unsigned int getCaretPosition() const;
 
+        /**
+         * Inserts UTF-8 encoded text at the caret position and moves the
+         * caret to the end of the inserted text. Does nothing if the text
+         * field is not editable.
+         *
+         * @param text The UTF-8 encoded text to insert.
+         * @see removeCharacters, isEditable
+         * @since 0.9.0
+         */
+        void insertText(const std::string& text);
+
+        /**
+         * Removes a number of characters at the caret position. A negative
+         * count removes characters left of the caret, a positive count
+         * removes characters right of the caret. A character is a whole
+         * UTF-8 sequence. Does nothing if the text field is not editable.
+         *
+         * @param count The number of characters to remove.
+         * @see insertText, isEditable
+         * @since 0.9.0
+         */
+        void removeCharacters(int count);
+
+        /**
+         * Gets the text object holding the content and the caret of the
+         * text field. Useful for measuring the text or the caret with a
+         * font, for example when drawing a subclass.
+         *
+         * @return The text object of the text field.
+         * @since 0.9.0
+         */
+        const Text& getTextObject() const;
+
 
         // Inherited from Widget
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -56,8 +56,10 @@ namespace gcn
 
     bool Key::isCharacter() const
     {
+        // Printable ASCII, Tab, and every Unicode code point above the
+        // C1 control range.
         return (mValue >= 32 && mValue <= 126)
-            || (mValue >= 162 && mValue <= 255)
+            || (mValue >= 160 && mValue <= 0x10FFFF)
             || (mValue == 9);
     }
 

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -52,6 +52,55 @@
 
 namespace gcn
 {
+    namespace
+    {
+        /**
+         * Checks if a byte is a UTF-8 continuation byte, that is a byte
+         * that does not start a new character.
+         */
+        bool isContinuationByte(char c)
+        {
+            return (c & 0xC0) == 0x80;
+        }
+
+        /**
+         * Encodes a Unicode code point as UTF-8. Values outside of the
+         * range 0 to 0x10FFFF result in an empty string.
+         */
+        std::string encodeUtf8(int character)
+        {
+            std::string result;
+
+            if (character < 0)
+                return result;
+
+            if (character < 0x80)
+            {
+                result += (char)character;
+            }
+            else if (character < 0x800)
+            {
+                result += (char)(0xC0 | (character >> 6));
+                result += (char)(0x80 | (character & 0x3F));
+            }
+            else if (character < 0x10000)
+            {
+                result += (char)(0xE0 | (character >> 12));
+                result += (char)(0x80 | ((character >> 6) & 0x3F));
+                result += (char)(0x80 | (character & 0x3F));
+            }
+            else if (character <= 0x10FFFF)
+            {
+                result += (char)(0xF0 | (character >> 18));
+                result += (char)(0x80 | ((character >> 12) & 0x3F));
+                result += (char)(0x80 | ((character >> 6) & 0x3F));
+                result += (char)(0x80 | (character & 0x3F));
+            }
+
+            return result;
+        }
+    }
+
     Text::Text()
         :mCaretPosition(0),
          mCaretRow(0),
@@ -191,30 +240,42 @@ namespace gcn
         return mRows[row];
     }
 
+    void Text::insert(const std::string& text)
+    {
+        if (mRows.empty())
+            mRows.push_back(std::string());
+
+        std::string::size_type start = 0;
+
+        while (true)
+        {
+            std::string::size_type pos = text.find('\n', start);
+
+            // No more line feeds, insert the rest into the current row.
+            if (pos == std::string::npos)
+            {
+                mRows[mCaretRow].insert(mCaretColumn, text, start,
+                                        std::string::npos);
+                setCaretColumn(mCaretColumn + (text.size() - start));
+                return;
+            }
+
+            // A line feed splits the current row at the caret. The part
+            // after the caret becomes a new row below the current one.
+            std::string tail = mRows[mCaretRow].substr(mCaretColumn);
+            mRows[mCaretRow].erase(mCaretColumn);
+            mRows[mCaretRow].append(text, start, pos - start);
+            mRows.insert(mRows.begin() + mCaretRow + 1, tail);
+
+            mCaretRow++;
+            mCaretColumn = 0;
+            start = pos + 1;
+        }
+    }
+
     void Text::insert(int character)
     {
-        char c = (char)character;
-
-        if (mRows.empty())
-        {
-             if (c == '\n')
-                 mRows.push_back("");
-             else
-                 mRows.push_back(std::string(1, c));
-        }
-        else
-        {
-            if (c == '\n')
-            {
-                mRows.insert(mRows.begin() + mCaretRow + 1,
-                             mRows[mCaretRow].substr(mCaretColumn, mRows[mCaretRow].size() - mCaretColumn));
-                mRows[mCaretRow].resize(mCaretColumn);
-            }
-            else
-                mRows[mCaretRow].insert(mCaretColumn, std::string(1, c));
-        }
-
-        setCaretPosition(getCaretPosition() + 1);
+        insert(encodeUtf8(character));
     }
 
     void Text::remove(int numberOfCharacters)
@@ -232,7 +293,7 @@ namespace gcn
                 if (mCaretPosition == 0)
                     break;
 
-                // If we are at the end of the row
+                // If we are at the start of the row
                 // and the row is not the first row we
                 // need to merge two rows.
                 if (mCaretColumn == 0 && mCaretRow != 0)
@@ -244,8 +305,10 @@ namespace gcn
                 }
                 else
                 {
-                    mRows[mCaretRow].erase(mCaretColumn - 1, 1);
-                    setCaretPosition(mCaretPosition - 1);
+                    unsigned int start = getPreviousCharacterColumn(
+                        mRows[mCaretRow], mCaretColumn);
+                    mRows[mCaretRow].erase(start, mCaretColumn - start);
+                    setCaretColumn(start);
                 }
 
                 numberOfCharacters++;
@@ -256,23 +319,24 @@ namespace gcn
         {
             while (numberOfCharacters != 0)
             {
-                // If all rows have been removed there is nothing
-                // more to do.
-                if (mRows.empty())
-                    break;
-
                 // If we are at the end of row and the row
                 // is not the last row we need to merge two
                 // rows.
-                if (mCaretColumn == mRows[mCaretRow].size()
-                    && mCaretRow < (mRows.size() - 1))
+                if (mCaretColumn == mRows[mCaretRow].size())
                 {
+                    // If this is the last row there is nothing
+                    // more to do.
+                    if (mCaretRow >= mRows.size() - 1)
+                        break;
+
                     mRows[mCaretRow] += mRows[mCaretRow + 1];
                     mRows.erase(mRows.begin() + mCaretRow + 1);
                 }
                 else
                 {
-                    mRows[mCaretRow].erase(mCaretColumn, 1);
+                    unsigned int end = getNextCharacterColumn(
+                        mRows[mCaretRow], mCaretColumn);
+                    mRows[mCaretRow].erase(mCaretColumn, end - mCaretColumn);
                 }
 
                 numberOfCharacters--;
@@ -444,6 +508,37 @@ namespace gcn
            return 0;
 
         return mRows[row].size();
+    }
+
+    unsigned int Text::getPreviousCharacterColumn(const std::string& row,
+                                                  unsigned int column)
+    {
+        if (column > row.size())
+            column = row.size();
+
+        while (column > 0)
+        {
+            column--;
+
+            if (!isContinuationByte(row[column]))
+                break;
+        }
+
+        return column;
+    }
+
+    unsigned int Text::getNextCharacterColumn(const std::string& row,
+                                              unsigned int column)
+    {
+        if (column >= row.size())
+            return row.size();
+
+        column++;
+
+        while (column < row.size() && isContinuationByte(row[column]))
+            column++;
+
+        return column;
     }
 
     void Text::calculateCaretPositionFromRowAndColumn()

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -131,11 +131,6 @@ namespace gcn
         while (pos != std::string::npos);
     }
 
-    Text::~Text()
-    {
-
-    }
-
     void Text::setContent(const std::string& content)
     {
         //reset caret

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -306,10 +306,12 @@ namespace gcn
                 // need to merge two rows.
                 if (mCaretColumn == 0 && mCaretRow != 0)
                 {
+                    // The caret ends up where the two rows were joined.
+                    unsigned int column = mRows[mCaretRow - 1].size();
                     mRows[mCaretRow - 1] += mRows[mCaretRow];
                     mRows.erase(mRows.begin() + mCaretRow);
-                    setCaretRow(mCaretRow - 1);
-                    setCaretColumn(getNumberOfCharacters(mCaretRow));
+                    mCaretRow--;
+                    setCaretColumn(column);
                 }
                 else
                 {

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -232,6 +232,14 @@ namespace gcn
         mRows.erase(mRows.begin() + row);
     }
 
+    const std::string& Text::getRow(unsigned int row) const
+    {
+        if (row >= mRows.size())
+            throw GCN_EXCEPTION("Row out of bounds!");
+
+        return mRows[row];
+    }
+
     std::string& Text::getRow(unsigned int row)
     {
         if (row >= mRows.size())
@@ -368,8 +376,9 @@ namespace gcn
             if (position <= (int)(total + mRows[i].size()))
             {
                 mCaretRow = i;
-                mCaretColumn = position - total;
-                mCaretPosition = position;
+                // Clamps the column to a character boundary and
+                // recalculates the caret position from it.
+                setCaretColumn(position - total);
                 return;
             }
 
@@ -413,7 +422,58 @@ namespace gcn
         else
             mCaretColumn = column;
 
+        // Move back to the start of the UTF-8 sequence if the column
+        // landed inside of one.
+        if (!mRows.empty())
+        {
+            const std::string& row = mRows[mCaretRow];
+            while (mCaretColumn > 0
+                   && mCaretColumn < row.size()
+                   && isContinuationByte(row[mCaretColumn]))
+                mCaretColumn--;
+        }
+
         calculateCaretPositionFromRowAndColumn();
+    }
+
+    void Text::moveCaretLeft()
+    {
+        if (mRows.empty())
+            return;
+
+        if (mCaretColumn == 0)
+        {
+            if (mCaretRow == 0)
+                return;
+
+            mCaretRow--;
+            setCaretColumn(mRows[mCaretRow].size());
+        }
+        else
+        {
+            setCaretColumn(getPreviousCharacterColumn(mRows[mCaretRow],
+                                                      mCaretColumn));
+        }
+    }
+
+    void Text::moveCaretRight()
+    {
+        if (mRows.empty())
+            return;
+
+        if (mCaretColumn >= mRows[mCaretRow].size())
+        {
+            if (mCaretRow + 1 >= mRows.size())
+                return;
+
+            mCaretRow++;
+            setCaretColumn(0);
+        }
+        else
+        {
+            setCaretColumn(getNextCharacterColumn(mRows[mCaretRow],
+                                                  mCaretColumn));
+        }
     }
 
     void Text::setCaretRow(int row)

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -538,10 +538,14 @@ namespace gcn
 
     unsigned int Text::getNumberOfCharacters() const
     {
-        unsigned int result = 0;
+        if (mRows.empty())
+            return 0;
+
+        // Count the line feeds between the rows.
+        unsigned int result = mRows.size() - 1;
         unsigned int i;
         for (i = 0; i < mRows.size(); ++i)
-            result += mRows[i].size() + 1;
+            result += getNumberOfCharacters(i);
 
         return result;
     }
@@ -552,6 +556,23 @@ namespace gcn
     }
 
     unsigned int Text::getNumberOfCharacters(unsigned int row) const
+    {
+        if (row >= mRows.size())
+           return 0;
+
+        const std::string& content = mRows[row];
+        unsigned int result = 0;
+        unsigned int column = 0;
+        while (column < content.size())
+        {
+            column = getNextCharacterColumn(content, column);
+            result++;
+        }
+
+        return result;
+    }
+
+    unsigned int Text::getNumberOfColumns(unsigned int row) const
     {
         if (row >= mRows.size())
            return 0;

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -235,14 +235,6 @@ namespace gcn
         return mRows[row];
     }
 
-    std::string& Text::getRow(unsigned int row)
-    {
-        if (row >= mRows.size())
-            throw GCN_EXCEPTION("Row out of bounds!");
-
-        return mRows[row];
-    }
-
     void Text::insert(const std::string& text)
     {
         if (mRows.empty())

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -95,23 +95,21 @@ namespace gcn
             graphics->fillRectangle(0, 0, getWidth(), getHeight());
         }
 
-        const Text& text = getTextObject();
-
         if (isFocused() && isEditable())
         {
             drawCaret(graphics,
-                      text.getCaretX(getFont()),
-                      text.getCaretY(getFont()));
+                      mText->getCaretX(getFont()),
+                      mText->getCaretY(getFont()));
         }
 
         graphics->setColor(getForegroundColor());
         graphics->setFont(getFont());
 
         unsigned int i;
-        for (i = 0; i < text.getNumberOfRows(); i++)
+        for (i = 0; i < mText->getNumberOfRows(); i++)
         {
             // Move the text one pixel so we can have a caret before a letter.
-            graphics->drawText(text.getRow(i), 1, i * getFont()->getHeight());
+            graphics->drawText(mText->getRow(i), 1, i * getFont()->getHeight());
         }
     }
 
@@ -301,11 +299,6 @@ namespace gcn
         mText->remove(count);
         adjustSize();
         scrollToCaret();
-    }
-
-    const Text& TextBox::getTextObject() const
-    {
-        return *mText;
     }
 
     void TextBox::addRow(const std::string &row)

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -138,10 +138,10 @@ namespace gcn
         Key key = keyEvent.getKey();
 
         if (key.getValue() == Key::Left)
-            mText->setCaretPosition(mText->getCaretPosition() - 1);
-        
+            mText->moveCaretLeft();
+
         else if (key.getValue() == Key::Right)
-            mText->setCaretPosition(mText->getCaretPosition() + 1);
+            mText->moveCaretRight();
 
         else if (key.getValue() == Key::Down)
             mText->setCaretRow(mText->getCaretRow() + 1);
@@ -187,12 +187,7 @@ namespace gcn
         }
 
         else if(key.getValue() == Key::Tab && mEditable)
-        {
-            mText->insert(' ');
-            mText->insert(' ');
-            mText->insert(' ');
-            mText->insert(' ');
-        }
+            mText->insert("    ");
 
         else if (key.isCharacter() && mEditable)
             mText->insert(key.getValue());

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -95,21 +95,23 @@ namespace gcn
             graphics->fillRectangle(0, 0, getWidth(), getHeight());
         }
 
+        const Text& text = getTextObject();
+
         if (isFocused() && isEditable())
         {
-            drawCaret(graphics, 
-                      mText->getCaretX(getFont()), 
-                      mText->getCaretY(getFont()));
+            drawCaret(graphics,
+                      text.getCaretX(getFont()),
+                      text.getCaretY(getFont()));
         }
 
         graphics->setColor(getForegroundColor());
         graphics->setFont(getFont());
 
         unsigned int i;
-        for (i = 0; i < mText->getNumberOfRows(); i++)
+        for (i = 0; i < text.getNumberOfRows(); i++)
         {
             // Move the text one pixel so we can have a caret before a letter.
-            graphics->drawText(mText->getRow(i), 1, i * getFont()->getHeight());
+            graphics->drawText(text.getRow(i), 1, i * getFont()->getHeight());
         }
     }
 
@@ -155,14 +157,14 @@ namespace gcn
         else if (key.getValue() == Key::End)
             mText->setCaretColumn(mText->getNumberOfCharacters(mText->getCaretRow()));
 
-        else if (key.getValue() == Key::Enter && mEditable)
-            mText->insert('\n');
+        else if (key.getValue() == Key::Enter)
+            insertText("\n");
 
-        else if (key.getValue() == Key::Backspace && mEditable)
-            mText->remove(-1);
+        else if (key.getValue() == Key::Backspace)
+            removeCharacters(-1);
 
-        else if (key.getValue() == Key::Delete && mEditable)
-            mText->remove(1);
+        else if (key.getValue() == Key::Delete)
+            removeCharacters(1);
 
         else if(key.getValue() == Key::PageUp)
         {
@@ -186,8 +188,8 @@ namespace gcn
             }
         }
 
-        else if(key.getValue() == Key::Tab && mEditable)
-            mText->insert("    ");
+        else if(key.getValue() == Key::Tab)
+            insertText("    ");
 
         else if (key.isCharacter() && mEditable)
             mText->insert(key.getValue());
@@ -279,6 +281,31 @@ namespace gcn
     bool TextBox::isEditable() const
     {
         return mEditable;
+    }
+
+    void TextBox::insertText(const std::string& text)
+    {
+        if (!mEditable)
+            return;
+
+        mText->insert(text);
+        adjustSize();
+        scrollToCaret();
+    }
+
+    void TextBox::removeCharacters(int count)
+    {
+        if (!mEditable)
+            return;
+
+        mText->remove(count);
+        adjustSize();
+        scrollToCaret();
+    }
+
+    const Text& TextBox::getTextObject() const
+    {
+        return *mText;
     }
 
     void TextBox::addRow(const std::string &row)

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -150,7 +150,7 @@ namespace gcn
             mText.setCaretColumn(0);
 
         else if (key.getValue() == Key::End)
-            mText.setCaretColumn(mText.getNumberOfCharacters(mText.getCaretRow()));
+            mText.setCaretColumn(mText.getNumberOfColumns(mText.getCaretRow()));
 
         else if (key.getValue() == Key::Enter)
             insertText("\n");

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -59,8 +59,6 @@ namespace gcn
         :mEditable(true),
          mOpaque(true)
     {
-        mText = new Text();
-
         setFocusable(true);
 
         addMouseListener(this);
@@ -69,11 +67,10 @@ namespace gcn
     }
 
     TextBox::TextBox(const std::string& text)
-        :mEditable(true),
+        :mText(text),
+         mEditable(true),
          mOpaque(true)
     {
-        mText = new Text(text);
-
         setFocusable(true);
 
         addMouseListener(this);
@@ -83,7 +80,7 @@ namespace gcn
 
     void TextBox::setText(const std::string& text)
     {
-        mText->setContent(text);
+        mText.setContent(text);
         adjustSize();
     }
 
@@ -98,18 +95,18 @@ namespace gcn
         if (isFocused() && isEditable())
         {
             drawCaret(graphics,
-                      mText->getCaretX(getFont()),
-                      mText->getCaretY(getFont()));
+                      mText.getCaretX(getFont()),
+                      mText.getCaretY(getFont()));
         }
 
         graphics->setColor(getForegroundColor());
         graphics->setFont(getFont());
 
         unsigned int i;
-        for (i = 0; i < mText->getNumberOfRows(); i++)
+        for (i = 0; i < mText.getNumberOfRows(); i++)
         {
             // Move the text one pixel so we can have a caret before a letter.
-            graphics->drawText(mText->getRow(i), 1, i * getFont()->getHeight());
+            graphics->drawText(mText.getRow(i), 1, i * getFont()->getHeight());
         }
     }
 
@@ -123,7 +120,7 @@ namespace gcn
     {
         if (mouseEvent.getButton() == MouseEvent::Left)
         {
-            mText->setCaretPosition(mouseEvent.getX(), mouseEvent.getY(), getFont());
+            mText.setCaretPosition(mouseEvent.getX(), mouseEvent.getY(), getFont());
             mouseEvent.consume();
         }
     }
@@ -138,22 +135,22 @@ namespace gcn
         Key key = keyEvent.getKey();
 
         if (key.getValue() == Key::Left)
-            mText->moveCaretLeft();
+            mText.moveCaretLeft();
 
         else if (key.getValue() == Key::Right)
-            mText->moveCaretRight();
+            mText.moveCaretRight();
 
         else if (key.getValue() == Key::Down)
-            mText->setCaretRow(mText->getCaretRow() + 1);
+            mText.setCaretRow(mText.getCaretRow() + 1);
 
         else if (key.getValue() == Key::Up)
-            mText->setCaretRow(mText->getCaretRow() - 1);
+            mText.setCaretRow(mText.getCaretRow() - 1);
 
         else if (key.getValue() == Key::Home)
-            mText->setCaretColumn(0);
+            mText.setCaretColumn(0);
 
         else if (key.getValue() == Key::End)
-            mText->setCaretColumn(mText->getNumberOfCharacters(mText->getCaretRow()));
+            mText.setCaretColumn(mText.getNumberOfCharacters(mText.getCaretRow()));
 
         else if (key.getValue() == Key::Enter)
             insertText("\n");
@@ -171,7 +168,7 @@ namespace gcn
             if (par != NULL)
             {
                 int rowsPerPage = par->getChildrenArea().height / getFont()->getHeight();
-                mText->setCaretRow(mText->getCaretRow() - rowsPerPage);
+                mText.setCaretRow(mText.getCaretRow() - rowsPerPage);
             }
         }
 
@@ -182,7 +179,7 @@ namespace gcn
             if (par != NULL)
             {
                 int rowsPerPage = par->getChildrenArea().height / getFont()->getHeight();
-                mText->setCaretRow(mText->getCaretRow() + rowsPerPage);
+                mText.setCaretRow(mText.getCaretRow() + rowsPerPage);
             }
         }
 
@@ -190,7 +187,7 @@ namespace gcn
             insertText("    ");
 
         else if (key.isCharacter() && mEditable)
-            mText->insert(key.getValue());
+            mText.insert(key.getValue());
 
         adjustSize();
         scrollToCaret();
@@ -200,65 +197,65 @@ namespace gcn
 
     void TextBox::adjustSize()
     {
-        const Rectangle& dim = mText->getDimension(getFont());
+        const Rectangle& dim = mText.getDimension(getFont());
         setSize(dim.width, dim.height);
     }
 
     void TextBox::setCaretPosition(unsigned int position)
     {
-        mText->setCaretPosition(position);
+        mText.setCaretPosition(position);
     }
 
     unsigned int TextBox::getCaretPosition() const
     {
-        return mText->getCaretPosition();
+        return mText.getCaretPosition();
     }
 
     void TextBox::setCaretRowColumn(int row, int column)
     {
-        mText->setCaretRow(row);
-        mText->setCaretColumn(column);
+        mText.setCaretRow(row);
+        mText.setCaretColumn(column);
     }
 
     void TextBox::setCaretRow(int row)
     {
-        mText->setCaretRow(row);
+        mText.setCaretRow(row);
     }
 
     unsigned int TextBox::getCaretRow() const
     {
-        return mText->getCaretRow();
+        return mText.getCaretRow();
     }
 
     void TextBox::setCaretColumn(int column)
     {
-        mText->setCaretColumn(column);
+        mText.setCaretColumn(column);
     }
 
     unsigned int TextBox::getCaretColumn() const
     {
-        return mText->getCaretColumn();
+        return mText.getCaretColumn();
     }
 
     std::string TextBox::getTextRow(int row) const
     {     
-        return mText->getRow(row);
+        return mText.getRow(row);
     }
 
     void TextBox::setTextRow(int row, const std::string& text)
     {
-        mText->setRow(row, text);
+        mText.setRow(row, text);
         adjustSize();
     }
 
     unsigned int TextBox::getNumberOfRows() const
     {
-        return mText->getNumberOfRows();
+        return mText.getNumberOfRows();
     }
 
     std::string TextBox::getText() const
     {
-        return mText->getContent();
+        return mText.getContent();
     }
 
     void TextBox::fontChanged()
@@ -268,7 +265,7 @@ namespace gcn
 
     void TextBox::scrollToCaret()
     {
-        showPart(mText->getCaretDimension(getFont()));
+        showPart(mText.getCaretDimension(getFont()));
     }
 
     void TextBox::setEditable(bool editable)
@@ -286,7 +283,7 @@ namespace gcn
         if (!mEditable)
             return;
 
-        mText->insert(text);
+        mText.insert(text);
         adjustSize();
         scrollToCaret();
     }
@@ -296,14 +293,14 @@ namespace gcn
         if (!mEditable)
             return;
 
-        mText->remove(count);
+        mText.remove(count);
         adjustSize();
         scrollToCaret();
     }
 
     void TextBox::addRow(const std::string &row)
     {
-        mText->addRow(row);
+        mText.addRow(row);
         adjustSize();
     }
 

--- a/src/widgets/textfield.cpp
+++ b/src/widgets/textfield.cpp
@@ -59,8 +59,6 @@ namespace gcn
         mEditable(true),
         mXScroll(0)
     {
-        mText = new Text();
-
         setFocusable(true);
 
         addMouseListener(this);
@@ -69,10 +67,9 @@ namespace gcn
 
     TextField::TextField(const std::string& text):
         mEditable(true),
+        mText(text),
         mXScroll(0)
     {
-        mText = new Text(text);
-
         adjustSize();
 
         setFocusable(true);
@@ -83,7 +80,7 @@ namespace gcn
 
     void TextField::setText(const std::string& text)
     {
-        mText->setContent(text);
+        mText.setContent(text);
     }
 
     void TextField::draw(Graphics* graphics)
@@ -120,14 +117,14 @@ namespace gcn
 
         if (isFocused() && isEditable())
         {
-            drawCaret(graphics, mText->getCaretX(getFont()) - mXScroll);
+            drawCaret(graphics, mText.getCaretX(getFont()) - mXScroll);
         }
 
         graphics->setColor(getForegroundColor());
         graphics->setFont(getFont());
 
-        if (mText->getNumberOfRows() != 0)
-            graphics->drawText(mText->getRow(0), 1 - mXScroll, 1);
+        if (mText.getNumberOfRows() != 0)
+            graphics->drawText(mText.getRow(0), 1 - mXScroll, 1);
 
         graphics->popClipArea();
     }
@@ -148,7 +145,7 @@ namespace gcn
     {
         if (mouseEvent.getButton() == MouseEvent::Left)
         {
-            mText->setCaretPosition(mouseEvent.getX() + mXScroll, mouseEvent.getY(), getFont());
+            mText.setCaretPosition(mouseEvent.getX() + mXScroll, mouseEvent.getY(), getFont());
             fixScroll();
         }
     }
@@ -163,10 +160,10 @@ namespace gcn
         Key key = keyEvent.getKey();
 
         if (key.getValue() == Key::Left)
-            mText->moveCaretLeft();
+            mText.moveCaretLeft();
 
         else if (key.getValue() == Key::Right)
-            mText->moveCaretRight();
+            mText.moveCaretRight();
 
         else if (key.getValue() == Key::Delete)
             removeCharacters(1);
@@ -178,15 +175,15 @@ namespace gcn
             distributeActionEvent();
 
         else if (key.getValue() == Key::Home)
-            mText->setCaretColumn(0);
+            mText.setCaretColumn(0);
 
         else if (key.getValue() == Key::End)
-            mText->setCaretColumn(mText->getNumberOfCharacters(0));
+            mText.setCaretColumn(mText.getNumberOfCharacters(0));
 
         else if (key.isCharacter()
                  && key.getValue() != Key::Tab
                  && mEditable)
-            mText->insert(key.getValue());
+            mText.insert(key.getValue());
 
         if (key.getValue() != Key::Tab)
             keyEvent.consume();
@@ -196,7 +193,7 @@ namespace gcn
 
     void TextField::adjustSize()
     {
-        const Rectangle& dim = mText->getDimension(getFont());
+        const Rectangle& dim = mText.getDimension(getFont());
         setWidth(dim.width + 8);
         adjustHeight();
 
@@ -212,7 +209,7 @@ namespace gcn
     {
         if (isFocused())
         {
-            int caretX = mText->getCaretDimension(getFont()).x;
+            int caretX = mText.getCaretDimension(getFont()).x;
 
             if (caretX - mXScroll >= getWidth() - 4)
             {
@@ -232,17 +229,17 @@ namespace gcn
 
     void TextField::setCaretPosition(unsigned int position)
     {
-        mText->setCaretPosition(position);
+        mText.setCaretPosition(position);
     }
 
     unsigned int TextField::getCaretPosition() const
     {
-        return  mText->getCaretPosition();
+        return  mText.getCaretPosition();
     }
 
     std::string TextField::getText() const
     {
-        return mText->getContent();
+        return mText.getContent();
     }
 
     bool TextField::isEditable() const
@@ -260,7 +257,7 @@ namespace gcn
         if (!mEditable)
             return;
 
-        mText->insert(text);
+        mText.insert(text);
         fixScroll();
     }
 
@@ -269,7 +266,7 @@ namespace gcn
         if (!mEditable)
             return;
 
-        mText->remove(count);
+        mText.remove(count);
         fixScroll();
     }
 }

--- a/src/widgets/textfield.cpp
+++ b/src/widgets/textfield.cpp
@@ -118,17 +118,18 @@ namespace gcn
             graphics->drawRectangle(1, 1, getWidth() - 4, getHeight() - 4);
         }
 
+        const Text& text = getTextObject();
+
         if (isFocused() && isEditable())
         {
-            drawCaret(graphics, mText->getCaretX(getFont()) - mXScroll);
+            drawCaret(graphics, text.getCaretX(getFont()) - mXScroll);
         }
 
         graphics->setColor(getForegroundColor());
         graphics->setFont(getFont());
 
-        const Rectangle& dim = mText->getCaretDimension(getFont());
-        if (mText->getNumberOfRows() != 0)
-            graphics->drawText(mText->getRow(0), 1 - mXScroll, 1);
+        if (text.getNumberOfRows() != 0)
+            graphics->drawText(text.getRow(0), 1 - mXScroll, 1);
 
         graphics->popClipArea();
     }
@@ -169,11 +170,11 @@ namespace gcn
         else if (key.getValue() == Key::Right)
             mText->moveCaretRight();
 
-        else if (key.getValue() == Key::Delete && mEditable)
-            mText->remove(1);
+        else if (key.getValue() == Key::Delete)
+            removeCharacters(1);
 
-        else if (key.getValue() == Key::Backspace && mEditable)
-            mText->remove(-1);
+        else if (key.getValue() == Key::Backspace)
+            removeCharacters(-1);
 
         else if (key.getValue() == Key::Enter)
             distributeActionEvent();
@@ -254,5 +255,28 @@ namespace gcn
     void TextField::setEditable(bool editable)
     {
         mEditable = editable;
+    }
+
+    void TextField::insertText(const std::string& text)
+    {
+        if (!mEditable)
+            return;
+
+        mText->insert(text);
+        fixScroll();
+    }
+
+    void TextField::removeCharacters(int count)
+    {
+        if (!mEditable)
+            return;
+
+        mText->remove(count);
+        fixScroll();
+    }
+
+    const Text& TextField::getTextObject() const
+    {
+        return *mText;
     }
 }

--- a/src/widgets/textfield.cpp
+++ b/src/widgets/textfield.cpp
@@ -118,18 +118,16 @@ namespace gcn
             graphics->drawRectangle(1, 1, getWidth() - 4, getHeight() - 4);
         }
 
-        const Text& text = getTextObject();
-
         if (isFocused() && isEditable())
         {
-            drawCaret(graphics, text.getCaretX(getFont()) - mXScroll);
+            drawCaret(graphics, mText->getCaretX(getFont()) - mXScroll);
         }
 
         graphics->setColor(getForegroundColor());
         graphics->setFont(getFont());
 
-        if (text.getNumberOfRows() != 0)
-            graphics->drawText(text.getRow(0), 1 - mXScroll, 1);
+        if (mText->getNumberOfRows() != 0)
+            graphics->drawText(mText->getRow(0), 1 - mXScroll, 1);
 
         graphics->popClipArea();
     }
@@ -273,10 +271,5 @@ namespace gcn
 
         mText->remove(count);
         fixScroll();
-    }
-
-    const Text& TextField::getTextObject() const
-    {
-        return *mText;
     }
 }

--- a/src/widgets/textfield.cpp
+++ b/src/widgets/textfield.cpp
@@ -178,7 +178,7 @@ namespace gcn
             mText.setCaretColumn(0);
 
         else if (key.getValue() == Key::End)
-            mText.setCaretColumn(mText.getNumberOfCharacters(0));
+            mText.setCaretColumn(mText.getNumberOfColumns(0));
 
         else if (key.isCharacter()
                  && key.getValue() != Key::Tab

--- a/src/widgets/textfield.cpp
+++ b/src/widgets/textfield.cpp
@@ -164,10 +164,10 @@ namespace gcn
         Key key = keyEvent.getKey();
 
         if (key.getValue() == Key::Left)
-            mText->setCaretPosition(mText->getCaretPosition() - 1);
+            mText->moveCaretLeft();
 
         else if (key.getValue() == Key::Right)
-            mText->setCaretPosition(mText->getCaretPosition() + 1);
+            mText->moveCaretRight();
 
         else if (key.getValue() == Key::Delete && mEditable)
             mText->remove(1);

--- a/src/widgets/textfield.cpp
+++ b/src/widgets/textfield.cpp
@@ -117,16 +117,51 @@ namespace gcn
 
         if (isFocused() && isEditable())
         {
-            drawCaret(graphics, mText.getCaretX(getFont()) - mXScroll);
+            drawCaret(graphics, getCaretX() - mXScroll);
         }
 
         graphics->setColor(getForegroundColor());
         graphics->setFont(getFont());
-
-        if (mText.getNumberOfRows() != 0)
-            graphics->drawText(mText.getRow(0), 1 - mXScroll, 1);
+        graphics->drawText(getDisplayText(), 1 - mXScroll, 1);
 
         graphics->popClipArea();
+    }
+
+    std::string TextField::getDisplayText() const
+    {
+        if (mText.getNumberOfRows() == 0)
+            return std::string();
+
+        return mText.getRow(0);
+    }
+
+    int TextField::getCaretX() const
+    {
+        if (mText.getNumberOfRows() == 0)
+            return 0;
+
+        // Count the characters before the caret in the stored text.
+        const std::string& row = mText.getRow(0);
+        const unsigned int caretColumn = mText.getCaretColumn();
+        unsigned int characters = 0;
+        unsigned int column = 0;
+        while (column < caretColumn)
+        {
+            column = Text::getNextCharacterColumn(row, column);
+            characters++;
+        }
+
+        // Measure that many characters of the display text, which may
+        // use a different number of bytes per character.
+        const std::string displayText = getDisplayText();
+        column = 0;
+        while (characters > 0 && column < displayText.size())
+        {
+            column = Text::getNextCharacterColumn(displayText, column);
+            characters--;
+        }
+
+        return getFont()->getWidth(displayText.substr(0, column));
     }
 
     void TextField::drawCaret(Graphics* graphics, int x)
@@ -209,7 +244,7 @@ namespace gcn
     {
         if (isFocused())
         {
-            int caretX = mText.getCaretDimension(getFont()).x;
+            int caretX = getCaretX();
 
             if (caretX - mXScroll >= getWidth() - 4)
             {


### PR DESCRIPTION
Makes `gcn::Text`, `TextField` and `TextBox` UTF-8 aware and gives the two widgets a small public editing API, so clients working with UTF-8 strings no longer have to reimplement Left, Right, Delete and Backspace in a subclass or poke at the protected `mText` member to insert pasted text.

This is a draft: the code is done and checked, but the API shape is up for review.

## Design

- Caret positions, rows and columns stay byte offsets, so they keep indexing the row strings directly and `getCaretPosition`/`setCaretPosition` keep their meaning. `getNumberOfCharacters` counts code points; `getNumberOfColumns` gives the byte length of a row.
- Every edit and caret step works on whole UTF-8 sequences, and the caret is kept on a sequence boundary: `setCaretPosition` and `setCaretColumn` clamp as before and then move back to the start of the sequence if they land on a continuation byte. This also covers mouse clicks, Up/Down and Home/End.
- Key values are treated as Unicode code points and UTF-8 encoded on insertion. `Key::isCharacter()` accepts printable ASCII, Tab and every code point from 160 to 0x10FFFF, so non-Latin-1 input from backends that deliver Unicode is inserted.
- `Text` is a plain value type (no virtuals) and the widgets hold it by value, which also fixes the leak of the pointer they never deleted. The mutable `getRow` overload is gone; rows change only through `insert`, `remove`, `setRow` and `setContent`.
- `TextField` draws the string returned by a protected virtual `getDisplayText()`, so a password field can mask the text without touching the stored row. The caret x is measured in the display text by character count, so the mask may use single-byte characters for multi-byte ones.
- A pre-existing bug came out in the checks and is fixed in its own commit: Backspace at column 0 placed the caret at the end of the merged row instead of at the join point.

## API changes

`gcn::Text`

- Class is non-virtual and copyable; the destructor is gone.
- `void insert(const std::string& text)`: inserts UTF-8 text at the caret, line feeds split rows, caret advances past the text.
- `void insert(int character)`: now encodes a code point (0 to 0x10FFFF) and calls the string version; other values are ignored.
- `void remove(int numberOfCharacters)`: counts whole UTF-8 sequences instead of bytes.
- `void moveCaretLeft()`, `void moveCaretRight()`: step one character, crossing rows like the Left and Right keys.
- `const std::string& getRow(unsigned int) const`: replaces the mutable overload.
- `unsigned int getNumberOfCharacters()` and `getNumberOfCharacters(unsigned int row)`: count code points now; the total counts one line feed between rows instead of one per row.
- `unsigned int getNumberOfColumns(unsigned int row)`: new, the byte length of a row (what caret columns are measured in).
- `static unsigned int getPreviousCharacterColumn(const std::string& row, unsigned int column)` and `getNextCharacterColumn(...)`: sequence boundary helpers.

`gcn::TextField` and `gcn::TextBox`

- `void insertText(const std::string& text)`: honours `isEditable()`, keeps scroll position (TextField) or size and scroll (TextBox) up to date.
- `void removeCharacters(int count)`: same, negative counts remove left of the caret.
- `Text mText` is held by value (was `Text*`).

`gcn::TextField` only

- `protected virtual std::string getDisplayText() const`: the text to draw, defaults to the stored text. Override for a password field.
- `protected int getCaretX() const`: caret x in pixels within the display text, before scrolling. Used by `draw` and `fixScroll`.

`gcn::Key`

- `isCharacter()` returns true for 32..126, Tab, and 160..0x10FFFF.

## Checks

Built with all backends off. A standalone program (not in the repo) exercised `Text` with "héllo wörld" and a 4-byte emoji: insert at the caret (string and code point, including line feeds), remove left and right across sequences, Left/Right stepping across rows, `setCaretPosition` and `setCaretColumn` landing inside a sequence, row merging on Backspace at column 0 and Delete at end of row, `getContent` round trips, code point versus byte counting, copying a `Text`, a masking `TextField` subclass whose caret x for "hé|llo" equals the width of two asterisks, `insertText`/`removeCharacters` through the widget, and `isCharacter` at the range edges (127, 128..159, 160, 255, 256, 0x1F600, 0x10FFFF, 0x110000). All 95 checks pass.

## Open questions

- `TextField::mousePressed` still maps the click x to a column using the stored text, so clicking in a masked field lands the caret slightly off when the mask changes character widths.
- `getNumberOfCharacters` changed meaning (bytes to code points); clients using it for End or caret arithmetic have to switch to `getNumberOfColumns`.
