### PR TITLE
Add SDL2 backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
           libgl1-mesa-dev \
           libsdl1.2-dev \
           libsdl-image1.2-dev \
+          libsdl2-dev \
+          libsdl2-image-dev \
           liballegro4-dev
 
     - name: Run autogen.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
           liballegro4-dev \
           libirrlicht-dev \
           libsdl-image1.2-dev \
-          libsdl1.2-dev
+          libsdl1.2-dev \
+          libsdl2-dev \
+          libsdl2-image-dev
     - name: Configure
       run: cmake -B build
     - name: Build
@@ -33,7 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         brew update
-        brew install cmake sdl12-compat
+        brew install cmake sdl12-compat sdl2 sdl2_image
     - name: Configure
       run: cmake -B build -DENABLE_OPENGL=OFF
     - name: Build
@@ -58,6 +60,8 @@ jobs:
           mingw-w64-x86_64-make
           mingw-w64-x86_64-SDL
           mingw-w64-x86_64-SDL_image
+          mingw-w64-x86_64-SDL2
+          mingw-w64-x86_64-SDL2_image
     - name: Configure
       run: cmake -B build
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(Allegro)
 find_package(OpenGL)
 find_package(SDL)
 find_package(SDL_image)
+find_package(SDL2 CONFIG)
+find_package(SDL2_image CONFIG)
 find_package(Irrlicht)
 
 # Set default values for options
@@ -30,9 +32,15 @@ if(SDL_FOUND AND SDLIMAGE_FOUND)
   set(SDL_DEFAULT ON)
 endif()
 
+set(SDL2_DEFAULT OFF)
+if(SDL2_FOUND AND SDL2_image_FOUND)
+  set(SDL2_DEFAULT ON)
+endif()
+
 option(ENABLE_ALLEGRO "Enable the Guichan Allegro extension" ${ALLEGRO_FOUND})
 option(ENABLE_OPENGL "Enable the Guichan OpenGL extension" ${OPENGL_FOUND})
 option(ENABLE_SDL "Enable the Guichan SDL extension" ${SDL_DEFAULT})
+option(ENABLE_SDL2 "Enable the Guichan SDL2 extension" ${SDL2_DEFAULT})
 option(ENABLE_IRRLICHT "Enable the Guichan Irrlicht extension" ${IRRLICHT_FOUND})
 
 option(BUILD_GUICHAN_SHARED
@@ -46,6 +54,9 @@ option(BUILD_GUICHAN_OPENGL_SHARED
 
 option(BUILD_GUICHAN_SDL_SHARED
        "Build the Guichan SDL extension library as a shared library." ON)
+
+option(BUILD_GUICHAN_SDL2_SHARED
+       "Build the Guichan SDL2 extension library as a shared library." ON)
 
 option(BUILD_GUICHAN_IRRLICHT_SHARED
        "Build the Guichan Irrlicht extension library as a shared library." ON)
@@ -319,6 +330,62 @@ if(ENABLE_SDL)
           DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
+# The Guichan SDL2 extension library
+if(ENABLE_SDL2)
+  if(NOT SDL2_FOUND OR NOT SDL2_image_FOUND)
+    message(FATAL_ERROR "SDL2 extension was enabled but SDL2 or SDL2_image libraries were not found.")
+  endif()
+
+  # The Guichan SDL2 extension source
+  file(GLOB GUICHAN_SDL2_HEADER include/guichan/sdl2.hpp)
+  file(GLOB GUICHAN_SDL2_HEADERS include/guichan/sdl2/*.hpp)
+  file(GLOB GUICHAN_SDL2_SRC src/sdl2/*.cpp)
+
+  # Grouping of the source for nicer display in IDEs such as Visual Studio
+  source_group(src/guichan FILES ${GUICHAN_SDL2_HEADER})
+  source_group(src/guichan/sdl2 FILES ${GUICHAN_SDL2_HEADERS} ${GUICHAN_SDL2_SRC})
+
+  if(BUILD_GUICHAN_SDL2_SHARED)
+    set(GUICHAN_SDL2_LIBRARY_TYPE SHARED)
+  else()
+    set(GUICHAN_SDL2_LIBRARY_TYPE STATIC)
+  endif()
+  add_library(
+    ${PROJECT_NAME}_sdl2
+    ${GUICHAN_SDL2_LIBRARY_TYPE} ${GUICHAN_SDL2_HEADER} ${GUICHAN_SDL2_HEADERS}
+    ${GUICHAN_SDL2_SRC})
+
+  # Older SDL2 CMake configs only provide variables instead of a target
+  if(TARGET SDL2::SDL2)
+    set(GUICHAN_SDL2_LIBRARIES SDL2::SDL2)
+  else()
+    target_include_directories(${PROJECT_NAME}_sdl2 PRIVATE ${SDL2_INCLUDE_DIRS})
+    set(GUICHAN_SDL2_LIBRARIES ${SDL2_LIBRARIES})
+  endif()
+
+  target_link_libraries(${PROJECT_NAME}_sdl2 PRIVATE ${PROJECT_NAME}
+                        ${GUICHAN_SDL2_LIBRARIES} SDL2_image::SDL2_image)
+
+  set_target_properties(
+    ${PROJECT_NAME}_sdl2 PROPERTIES VERSION ${PROJECT_VERSION}
+                                    SOVERSION ${PROJECT_SOVERSION})
+  install(
+    TARGETS ${PROJECT_NAME}_sdl2
+    EXPORT ${PROJECT_NAME}Targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(FILES ${GUICHAN_SDL2_HEADER} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/guichan/)
+  install(FILES ${GUICHAN_SDL2_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/guichan/sdl2/)
+
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/guichan_sdl2.pc.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/guichan_sdl2.pc @ONLY)
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/guichan_sdl2.pc
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()
+
 if(ENABLE_IRRLICHT)
   if(NOT IRRLICHT_FOUND)
     message(FATAL_ERROR "Irrlicht extension was enabled but Irrlicht library was not found")
@@ -383,6 +450,7 @@ message(STATUS "  Extensions:")
 message(STATUS "    Allegro:        ${ENABLE_ALLEGRO}")
 message(STATUS "    OpenGL:         ${ENABLE_OPENGL}")
 message(STATUS "    SDL:            ${ENABLE_SDL}")
+message(STATUS "    SDL2:           ${ENABLE_SDL2}")
 message(STATUS "    Irrlicht:       ${ENABLE_IRRLICHT}")
 message(STATUS "")
 message(STATUS "  Library types:")
@@ -395,6 +463,9 @@ if(ENABLE_OPENGL AND OPENGL_FOUND)
 endif()
 if(ENABLE_SDL AND SDL_FOUND AND SDLIMAGE_FOUND)
   message(STATUS "    SDL:            ${GUICHAN_SDL_LIBRARY_TYPE}")
+endif()
+if(ENABLE_SDL2 AND SDL2_FOUND AND SDL2_image_FOUND)
+  message(STATUS "    SDL2:           ${GUICHAN_SDL2_LIBRARY_TYPE}")
 endif()
 if(ENABLE_IRRLICHT AND IRRLICHT_FOUND)
   message(STATUS "    Irrlicht:       ${GUICHAN_IRRLICHT_LIBRARY_TYPE}")

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,5 +10,6 @@ EXTRA_DIST = guichan.pc.in \
              guichan_irrlicht.pc.in \
              guichan_opengl.pc.in \
              guichan_sdl.pc.in \
+             guichan_sdl2.pc.in \
              CMakeLists.txt \
              CMake/Modules/FindAllegro.cmake

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ ALLEGRO="disabled"
 OPENGL="disabled"
 SDL="disabled"
 SDLIMAGE="disabled"
+SDL2="disabled"
 dnl GLUT="disabled"
 dnl X="disabled"
 
@@ -275,6 +276,19 @@ else
   AM_CONDITIONAL([WITH_SDL], [false])
 fi
 
+AC_ARG_ENABLE(sdl2,
+[  --enable-sdl2	  Enable SDL2 support [default=yes]],
+             , enable_sdl2=yes)
+if test x$enable_sdl2 = xyes; then
+  PKG_CHECK_MODULES([SDL2], [sdl2 SDL2_image], [SDL2="yes"], [
+    SDL2="no"
+    AC_MSG_WARN(SDL2 support skipped when SDL2 or SDL2_image not found.)
+  ])
+else
+  SDL2="no"
+fi
+AM_CONDITIONAL([WITH_SDL2], [test x$SDL2 = xyes])
+
 AC_CONFIG_FILES([
 Makefile
 guichan.pc
@@ -291,6 +305,7 @@ include/guichan/hge/Makefile
 include/guichan/opengl/Makefile
 include/guichan/openlayer/Makefile
 include/guichan/sdl/Makefile
+include/guichan/sdl2/Makefile
 include/guichan/widgets/Makefile
 src/Makefile
 src/allegro/Makefile
@@ -305,6 +320,8 @@ src/opengl/guichan_opengl.pc
 src/openlayer/Makefile
 src/sdl/Makefile
 src/sdl/guichan_sdl.pc
+src/sdl2/Makefile
+src/sdl2/guichan_sdl2.pc
 src/widgets/Makefile])
 AC_OUTPUT
 echo ""
@@ -322,4 +339,5 @@ echo "* OpenGL    = "$OPENGL
 echo "* OpenLayer = no (Requires static build and cannot be built)"
 echo "* SDL       = "$SDL
 echo "* SDL Image = "$SDLIMAGE
+echo "* SDL2      = "$SDL2
 echo "--------------------------------"

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -24,6 +24,9 @@ EXTRA_DIST =                  		\
 	openlayer.hpp			\
 	openlayerwidgets.cpp		\
 	sdl.hpp				\
+	sdl2.hpp			\
+	sdl2helloworld.cpp		\
+	sdl2widgets.cpp			\
 	sdlaction.cpp			\
 	sdlhelloworld.cpp		\
 	sdlwidgets.cpp			\

--- a/examples/Makefile.examples
+++ b/examples/Makefile.examples
@@ -1,6 +1,6 @@
 CFLAGS = -Werror -Wall -Wno-unused
 
-all: allegro openglallegro openglsdl sdl
+all: allegro openglallegro openglsdl sdl sdl2
 
 allegro:
 	g++ allegrohelloworld.cpp -o allegrohelloworld $(CFLAGS) \
@@ -34,8 +34,15 @@ sdl:
 	g++ sdlaction.cpp -o sdlaction $(CFLAGS) \
 	-lguichan_sdl -lguichan -lSDL_image `sdl-config --libs --cflags`
 
+sdl2:
+	g++ sdl2helloworld.cpp -o sdl2helloworld $(CFLAGS) \
+	-lguichan_sdl2 -lguichan -lSDL2_image `sdl2-config --libs --cflags`
+	g++ sdl2widgets.cpp -o sdl2widgets $(CFLAGS) \
+	-lguichan_sdl2 -lguichan -lSDL2_image `sdl2-config --libs --cflags`
+
 clean:
 	rm -f allegroaction allegrohelloworld allegrowidgets
 	rm -f openglallegroaction openglallegrohelloworld openglallegrowidgets
 	rm -f openglsdlaction openglsdlhelloworld openglsdlwidgets
 	rm -f sdlaction sdlhelloworld sdlwidgets
+	rm -f sdl2helloworld sdl2widgets

--- a/examples/sdl2.hpp
+++ b/examples/sdl2.hpp
@@ -1,0 +1,120 @@
+/*
+ * Code that sets up an SDL2 application with Guichan using the
+ * Guichan SDL2 back end.
+ */
+
+#include <guichan.hpp>
+#include <guichan/sdl2.hpp>
+
+namespace sdl2
+{
+    bool running = true;
+    SDL_Window* window;
+    SDL_Renderer* renderer;
+
+    // All back ends contain objects to make Guichan work on a
+    // specific target - in this case SDL2 - and they are a Graphics
+    // object to make Guichan able to draw itself using SDL2, an
+    // input objec to make Guichan able to get user input using SDL2
+    // and an ImageLoader object to make Guichan able to load images
+    // using SDL2.
+    gcn::SDL2Graphics* graphics;
+    gcn::SDL2Input* input;
+    gcn::SDL2ImageLoader* imageLoader;
+
+    /**
+     * Initialises the SDL2 application. This function creates the global
+     * Gui object that can be populated by various examples.
+     */
+    void init()
+    {
+        // We simply initialise SDL2 as we would do with any SDL2 application.
+        SDL_Init(SDL_INIT_VIDEO);
+        window = SDL_CreateWindow("Guichan SDL2 example",
+                                  SDL_WINDOWPOS_UNDEFINED,
+                                  SDL_WINDOWPOS_UNDEFINED,
+                                  640, 480, 0);
+        // Guichan draws with a renderer, and images become textures of it.
+        renderer = SDL_CreateRenderer(window, -1, 0);
+        // Text is delivered to the SDL2Input object through text input
+        // events, which we make sure are enabled.
+        SDL_StartTextInput();
+
+        // Now it's time to initialise the Guichan SDL2 back end.
+
+        // The image loader needs the renderer to create textures for it.
+        imageLoader = new gcn::SDL2ImageLoader(renderer);
+        // The ImageLoader Guichan should use needs to be passed to the Image object
+        // using a static function.
+        gcn::Image::setImageLoader(imageLoader);
+        // The Graphics object draws with the renderer.
+        graphics = new gcn::SDL2Graphics(renderer);
+        input = new gcn::SDL2Input();
+
+        // Now we create the Gui object to be used with this SDL2 application.
+        globals::gui = new gcn::Gui();
+        // The Gui object needs a Graphics to be able to draw itself and an Input
+        // object to be able to check for user input. In this case we provide the
+        // Gui object with SDL2 implementations of these objects hence making Guichan
+        // able to utilise SDL2.
+        globals::gui->setGraphics(graphics);
+        globals::gui->setInput(input);
+    }
+
+    /**
+     * Halts the SDL2 application.
+     */
+    void halt()
+    {
+        delete globals::gui;
+
+        delete imageLoader;
+        delete input;
+        delete graphics;
+
+        SDL_DestroyRenderer(renderer);
+        SDL_DestroyWindow(window);
+        SDL_Quit();
+    }
+
+    /**
+     * Runs the SDL2 application.
+     */
+    void run()
+    {
+        // The main loop
+        while(running)
+        {
+            // Check user input
+            SDL_Event event;
+            while(SDL_PollEvent(&event))
+            {
+                if (event.type == SDL_KEYDOWN)
+                {
+                    if (event.key.keysym.sym == SDLK_ESCAPE)
+                    {
+                        running = false;
+                    }
+                }
+                else if(event.type == SDL_QUIT)
+                {
+                    running = false;
+                }
+
+                // After we have manually checked user input with SDL2 for
+                // any attempt by the user to halt the application we feed
+                // the input to Guichan by pushing the input to the Input
+                // object.
+                input->pushInput(event);
+            }
+            // Now we let the Gui object perform its logic.
+            globals::gui->logic();
+            // We clear the screen before letting the Gui object draw itself.
+            SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+            SDL_RenderClear(renderer);
+            globals::gui->draw();
+            // Finally we present what has been drawn.
+            SDL_RenderPresent(renderer);
+        }
+    }
+}

--- a/examples/sdl2helloworld.cpp
+++ b/examples/sdl2helloworld.cpp
@@ -1,0 +1,58 @@
+/**
+ * This is an example that shows a simple Hello World example
+ * with Guichan. The example uses the SDL2 back end.
+ */
+
+#include <guichan.hpp>
+#include <iostream>
+
+// Here we store a global Gui object.  We make it global
+// so it's easily accessable. Of course, global variables
+// should normally be avioded when it comes to OOP, but
+// this examples is not an example that shows how to make a
+// good and clean C++ application but merely an example
+// that shows how to use Guichan.
+namespace globals
+{
+    gcn::Gui* gui;
+}
+
+// Include code to set up an SDL2 application with Guichan.
+// The sdl2.hpp file is responsible for creating and deleting
+// the global Gui object.
+#include "sdl2.hpp"
+// Include code to set up a Guichan GUI with a simple Hello
+// World example. The code populates the global Gui object.
+#include "helloworld.hpp"
+
+int main(int argc, char **argv)
+{
+    try
+    {
+        sdl2::init();
+        helloworld::init();
+        sdl2::run();
+        helloworld::halt();
+        sdl2::halt();
+    }
+    // Catch all Guichan exceptions.
+    catch (gcn::Exception e)
+    {
+        std::cerr << e.getMessage() << std::endl;
+        return 1;
+    }
+    // Catch all Std exceptions.
+    catch (std::exception e)
+    {
+        std::cerr << "Std exception: " << e.what() << std::endl;
+        return 1;
+    }
+    // Catch all unknown exceptions.
+    catch (...)
+    {
+        std::cerr << "Unknown exception" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/examples/sdl2widgets.cpp
+++ b/examples/sdl2widgets.cpp
@@ -1,0 +1,58 @@
+/**
+ * This is an example that shows of the widgets present in
+ * Guichan. The example uses the SDL2 back end.
+ */
+
+#include <guichan.hpp>
+#include <iostream>
+
+// Here we store a global Gui object.  We make it global
+// so it's easily accessable. Of course, global variables
+// should normally be avioded when it comes to OOP, but
+// this examples is not an example that shows how to make a
+// good and clean C++ application but merely an example
+// that shows how to use Guichan.
+namespace globals
+{
+    gcn::Gui* gui;
+}
+
+// Include code to set up an SDL2 application with Guichan.
+// The sdl2.hpp file is responsible for creating and deleting
+// the global Gui object.
+#include "sdl2.hpp"
+// Include code to set up a Guichan GUI with all the widgets
+// of Guichan. The code populates the global Gui object.
+#include "widgets.hpp"
+
+int main(int argc, char **argv)
+{
+    try
+    {
+        sdl2::init();
+        widgets::init();
+        sdl2::run();
+        widgets::halt();
+        sdl2::halt();
+    }
+    // Catch all Guichan exceptions.
+    catch (gcn::Exception e)
+    {
+        std::cerr << e.getMessage() << std::endl;
+        return 1;
+    }
+    // Catch all Std exceptions.
+    catch (std::exception e)
+    {
+        std::cerr << "Std exception: " << e.what() << std::endl;
+        return 1;
+    }
+    // Catch all unknown exceptions.
+    catch (...)
+    {
+        std::cerr << "Unknown exception" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/guichan_sdl2.pc.in
+++ b/guichan_sdl2.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: guichan_sdl2
+Description: SDL2 extension for the Guichan GUI library
+Version: @PROJECT_VERSION@
+Requires: guichan
+Libs: -L${libdir} -lguichan_sdl2
+Cflags: -I${includedir}

--- a/include/guichan/Makefile.am
+++ b/include/guichan/Makefile.am
@@ -9,6 +9,10 @@ if WITH_SDL
 SUBDIRS += sdl
 endif
 
+if WITH_SDL2
+SUBDIRS += sdl2
+endif
+
 if WITH_OPENGL
 SUBDIRS += opengl
 endif
@@ -53,6 +57,7 @@ libguichaninclude_HEADERS =	\
 	selectionevent.hpp	\
 	selectionlistener.hpp	\
 	sdl.hpp			\
+	sdl2.hpp		\
 	text.hpp		\
 	textevent.hpp		\
 	textinput.hpp		\

--- a/include/guichan/sdl2.hpp
+++ b/include/guichan/sdl2.hpp
@@ -1,0 +1,62 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GCN_SDL2_HPP
+#define GCN_SDL2_HPP
+
+#include <guichan/sdl2/sdl2graphics.hpp>
+#include <guichan/sdl2/sdl2image.hpp>
+#include <guichan/sdl2/sdl2imageloader.hpp>
+#include <guichan/sdl2/sdl2input.hpp>
+
+#include "platform.hpp"
+
+extern "C"
+{
+    /**
+     * Exists to be able to check for Guichan SDL2 with autotools.
+     */
+    GCN_EXTENSION_DECLSPEC extern void gcnSDL2();
+}
+
+#endif // end GCN_SDL2_HPP

--- a/include/guichan/sdl2/Makefile.am
+++ b/include/guichan/sdl2/Makefile.am
@@ -1,0 +1,7 @@
+libguichanincludedir = $(includedir)/guichan/sdl2
+
+libguichaninclude_HEADERS =	\
+	sdl2graphics.hpp	\
+	sdl2image.hpp		\
+	sdl2imageloader.hpp	\
+	sdl2input.hpp

--- a/include/guichan/sdl2/sdl2graphics.hpp
+++ b/include/guichan/sdl2/sdl2graphics.hpp
@@ -1,0 +1,158 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GCN_SDL2GRAPHICS_HPP
+#define GCN_SDL2GRAPHICS_HPP
+
+#include "SDL.h"
+
+#include "guichan/color.hpp"
+#include "guichan/graphics.hpp"
+#include "guichan/platform.hpp"
+
+namespace gcn
+{
+    class Image;
+    class Rectangle;
+
+    /**
+     * SDL2 implementation of the Graphics. It draws with an SDL_Renderer,
+     * so images need to be SDL2Image objects converted to display format,
+     * which turns them into textures of that renderer. The application
+     * is responsible for clearing and presenting the renderer, for example
+     * with SDL_RenderClear before Gui::draw and SDL_RenderPresent after
+     * it.
+     */
+    class GCN_EXTENSION_DECLSPEC SDL2Graphics : public Graphics
+    {
+    public:
+
+        // Needed so that drawImage(gcn::Image *, int, int) is visible.
+        using Graphics::drawImage;
+
+        /**
+         * Constructor.
+         *
+         * @param renderer the renderer to draw with. May be NULL, in which
+         *                 case a renderer has to be set with setTarget
+         *                 before drawing.
+         */
+        SDL2Graphics(SDL_Renderer* renderer = NULL);
+
+        /**
+         * Sets the target SDL_Renderer to draw with. The renderer's draw
+         * blend mode is set to SDL_BLENDMODE_BLEND so that the alpha of
+         * the current color is respected.
+         *
+         * @param renderer the renderer to draw with.
+         */
+        virtual void setTarget(SDL_Renderer* renderer);
+
+        /**
+         * Gets the target SDL_Renderer.
+         *
+         * @return the target SDL_Renderer.
+         */
+        virtual SDL_Renderer* getTarget() const;
+
+        /**
+         * Draws an SDL_Texture with the target renderer. Normaly you'll
+         * use drawImage, but if you want to write SDL specific code
+         * this function might come in handy.
+         *
+         * NOTE: The clip areas will be taken into account.
+         */
+        virtual void drawSDLTexture(SDL_Texture* texture,
+                                    SDL_Rect source,
+                                    SDL_Rect destination);
+
+
+        // Inherited from Graphics
+
+        virtual void _beginDraw();
+
+        virtual void _endDraw();
+
+        virtual bool pushClipArea(Rectangle area);
+
+        virtual void popClipArea();
+
+        virtual void drawImage(const Image* image,
+                               int srcX,
+                               int srcY,
+                               int dstX,
+                               int dstY,
+                               int width,
+                               int height);
+
+        virtual void drawPoint(int x, int y);
+
+        virtual void drawLine(int x1, int y1, int x2, int y2);
+
+        virtual void drawRectangle(const Rectangle& rectangle);
+
+        virtual void fillRectangle(const Rectangle& rectangle);
+
+        virtual void setColor(const Color& color);
+
+        virtual const Color& getColor() const;
+
+    protected:
+        /**
+         * Applies the top of the clip stack as the renderer's clip
+         * rectangle, or removes the clip rectangle when the stack is
+         * empty.
+         */
+        void updateClipRect();
+
+        /**
+         * Sets the current color as the renderer's draw color.
+         */
+        void applyColor();
+
+        SDL_Renderer* mRenderer;
+        Color mColor;
+    };
+}
+
+#endif // end GCN_SDL2GRAPHICS_HPP

--- a/include/guichan/sdl2/sdl2image.hpp
+++ b/include/guichan/sdl2/sdl2image.hpp
@@ -1,0 +1,149 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GCN_SDL2IMAGE_HPP
+#define GCN_SDL2IMAGE_HPP
+
+#include "SDL.h"
+
+#include <string>
+
+#include "guichan/color.hpp"
+#include "guichan/platform.hpp"
+#include "guichan/image.hpp"
+
+namespace gcn
+{
+    /**
+     * SDL2 implementation of Image. Before conversion to display format
+     * the image holds an SDL_Surface, whose pixels can be read and
+     * written. Conversion turns the surface into an SDL_Texture of the
+     * renderer the image was created with, after which the pixels can no
+     * longer be accessed.
+     */
+    class GCN_EXTENSION_DECLSPEC SDL2Image : public Image
+    {
+    public:
+        /**
+         * Constructor. Load an image from an SDL surface.
+         *
+         * NOTE: The functions getPixel and putPixel only work before an
+         *       image has been converted to display format.
+         *
+         * @param surface the surface from which to load.
+         * @param renderer the renderer the texture is created for when
+         *                 the image is converted to display format.
+         * @param autoFree true if the surface and the texture should
+         *                 automatically be released. When false, the
+         *                 surface is left to the caller after conversion
+         *                 and free() needs to be called to release the
+         *                 texture.
+         */
+        SDL2Image(SDL_Surface* surface, SDL_Renderer* renderer, bool autoFree);
+
+        /**
+         * Constructor. Load an image from an existing SDL texture. The
+         * image counts as converted to display format.
+         *
+         * @param texture the texture from which to load.
+         * @param width the width of the image.
+         * @param height the height of the image.
+         * @param autoFree true if the texture should automatically be
+         *                 destroyed.
+         */
+        SDL2Image(SDL_Texture* texture, int width, int height, bool autoFree);
+
+        /**
+         * Destructor.
+         */
+        virtual ~SDL2Image();
+
+        /**
+         * Gets the SDL surface for the image.
+         *
+         * @return the SDL surface for the image, or NULL when the image
+         *         has been converted to display format.
+         */
+        virtual SDL_Surface* getSurface() const;
+
+        /**
+         * Gets the SDL texture for the image.
+         *
+         * @return the SDL texture for the image, or NULL when the image
+         *         has not been converted to display format.
+         */
+        virtual SDL_Texture* getTexture() const;
+
+
+        // Inherited from Image
+
+        virtual void free();
+
+        virtual int getWidth() const;
+
+        virtual int getHeight() const;
+
+        virtual Color getPixel(int x, int y);
+
+        virtual void putPixel(int x, int y, const Color& color);
+
+        /**
+         * Creates a texture from the surface for the renderer given at
+         * construction and releases the surface. Pixels in pink
+         * (255, 0, 255) become transparent, and the texture gets the
+         * blend mode SDL_BLENDMODE_BLEND so that per pixel alpha is
+         * respected when drawing.
+         */
+        virtual void convertToDisplayFormat();
+
+    protected:
+        SDL_Surface* mSurface;
+        SDL_Texture* mTexture;
+        SDL_Renderer* mRenderer;
+        int mWidth;
+        int mHeight;
+        bool mAutoFree;
+    };
+}
+
+#endif // end GCN_SDL2IMAGE_HPP

--- a/include/guichan/sdl2/sdl2imageloader.hpp
+++ b/include/guichan/sdl2/sdl2imageloader.hpp
@@ -1,0 +1,111 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GCN_SDL2IMAGELOADER_HPP
+#define GCN_SDL2IMAGELOADER_HPP
+
+#include "guichan/imageloader.hpp"
+#include "guichan/platform.hpp"
+
+#include "SDL.h"
+
+namespace gcn
+{
+    class Image;
+
+    /**
+     * SDL2 implementation of ImageLoader. Images are loaded with SDL2_image
+     * into a 32 bit RGBA surface and become textures of the renderer given
+     * to the loader when they are converted to display format.
+     *
+     * NOTE: Converting an image to display format makes its pixels
+     *       inaccessible. ImageFont reads the pixels of its image to find
+     *       the glyphs, so it loads with convertToDisplayFormat set to
+     *       false and converts the image afterwards. Do the same for any
+     *       image whose pixels you need to inspect or change.
+     */
+    class GCN_EXTENSION_DECLSPEC SDL2ImageLoader : public ImageLoader
+    {
+    public:
+
+        /**
+         * Constructor.
+         *
+         * @param renderer the renderer the loaded images create their
+         *                 textures for. May be NULL, in which case a
+         *                 renderer has to be set with setRenderer before
+         *                 loading images.
+         */
+        SDL2ImageLoader(SDL_Renderer* renderer = NULL);
+
+        /**
+         * Sets the renderer the loaded images create their textures for.
+         * Images loaded before the call are not affected.
+         *
+         * @param renderer the renderer to create textures for.
+         * @see getRenderer
+         */
+        void setRenderer(SDL_Renderer* renderer);
+
+        /**
+         * Gets the renderer the loaded images create their textures for.
+         *
+         * @return the renderer to create textures for.
+         * @see setRenderer
+         */
+        SDL_Renderer* getRenderer() const;
+
+
+        // Inherited from ImageLoader
+
+        virtual Image* load(const std::string& filename, bool convertToDisplayFormat = true);
+
+    protected:
+        virtual SDL_Surface* loadSDLSurface(const std::string& filename);
+        virtual SDL_Surface* convertToStandardFormat(SDL_Surface* surface);
+
+        SDL_Renderer* mRenderer;
+    };
+}
+
+#endif // end GCN_SDL2IMAGELOADER_HPP

--- a/include/guichan/sdl2/sdl2input.hpp
+++ b/include/guichan/sdl2/sdl2input.hpp
@@ -1,0 +1,159 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GCN_SDL2INPUT_HPP
+#define GCN_SDL2INPUT_HPP
+
+#include <queue>
+
+#include "SDL.h"
+
+#include "guichan/input.hpp"
+#include "guichan/keyinput.hpp"
+#include "guichan/mouseinput.hpp"
+#include "guichan/platform.hpp"
+#include "guichan/textinput.hpp"
+
+namespace gcn
+{
+    class Key;
+
+    /**
+     * SDL2 implementation of Input.
+     *
+     * Every SDL_KEYDOWN and SDL_KEYUP event becomes a KeyInput. Keys that
+     * do not produce text are mapped to the Key constants, other keys
+     * carry their SDL key code, which is the character of the key without
+     * modifiers, so Ctrl+V is delivered as the key 'v' with
+     * isControlPressed() set.
+     *
+     * Entered text is taken from SDL_TEXTINPUT events and delivered
+     * through the text queue as UTF-8 strings, so hasTextInput() returns
+     * true and the Gui never derives text from key presses. This makes
+     * text entry work for any layout, dead keys, compose sequences and
+     * input methods. The application has to enable text input with
+     * SDL_StartTextInput() for these events to arrive, and can use
+     * SDL_SetTextInputRect() to let input methods place their candidate
+     * window next to the focused widget. Text being composed by an input
+     * method (SDL_TEXTEDITING) is not delivered, only the committed text.
+     */
+    class GCN_EXTENSION_DECLSPEC SDL2Input : public Input
+    {
+    public:
+
+        /**
+         * Constructor.
+         */
+        SDL2Input();
+
+        /**
+         * Pushes an SDL event. It should be called at least once per frame to
+         * update input with user input.
+         *
+         * @param event an event from SDL.
+         */
+        virtual void pushInput(SDL_Event event);
+
+        /**
+         * Polls all input. It exists for input driver compatibility. If you
+         * only use SDL and plan sticking with SDL you can safely ignore this
+         * function as it in the SDL case does nothing.
+         */
+        virtual void _pollInput() { }
+
+
+        // Inherited from Input
+
+        virtual bool isKeyQueueEmpty();
+
+        virtual KeyInput dequeueKeyInput();
+
+        virtual bool isMouseQueueEmpty();
+
+        virtual MouseInput dequeueMouseInput();
+
+        virtual bool hasTextInput();
+
+        virtual bool isTextQueueEmpty();
+
+        virtual TextInput dequeueTextInput();
+
+    protected:
+        /**
+         * Converts a mouse button from SDL to a Guichan mouse button
+         * representation.
+         *
+         * @param button an SDL mouse button.
+         * @return a Guichan mouse button.
+         */
+        int convertMouseButton(int button);
+
+        /**
+         * Converts an SDL key event to a Guichan key value.
+         *
+         * @param event The SDL key event to convert.
+         * @return A Guichan key value. -1 if no conversion took place.
+         * @see Key
+         */
+        int convertSDLEventToGuichanKeyValue(SDL_Event event);
+
+        /**
+         * Checks whether an SDL scan code belongs to the numeric pad.
+         *
+         * @param scancode an SDL scan code.
+         * @return true if the scan code belongs to the numeric pad.
+         */
+        bool isNumericPadKey(SDL_Scancode scancode);
+
+        std::queue<KeyInput> mKeyInputQueue;
+        std::queue<MouseInput> mMouseInputQueue;
+        std::queue<TextInput> mTextInputQueue;
+
+        bool mMouseDown;
+        bool mMouseInWindow;
+        int mMouseX;
+        int mMouseY;
+    };
+}
+
+#endif // end GCN_SDL2INPUT_HPP

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,6 +12,10 @@ if WITH_SDL
 SUBDIRS += sdl
 endif
 
+if WITH_SDL2
+SUBDIRS += sdl2
+endif
+
 if WITH_OPENGL
 SUBDIRS += opengl
 endif

--- a/src/sdl2/Makefile.am
+++ b/src/sdl2/Makefile.am
@@ -1,0 +1,18 @@
+lib_LTLIBRARIES = libguichan_sdl2.la
+
+AM_CPPFLAGS = -I$(top_srcdir)/include $(SDL2_CFLAGS)
+
+libguichan_sdl2_la_LIBADD  = $(top_builddir)/src/libguichan.la $(SDL2_LIBS)
+libguichan_sdl2_la_LDFLAGS = -no-undefined -release $(LT_RELEASE) -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
+
+libguichan_sdl2_la_SOURCES =	\
+	sdl2.cpp		\
+	sdl2graphics.cpp	\
+	sdl2image.cpp		\
+	sdl2imageloader.cpp	\
+	sdl2input.cpp
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = guichan_sdl2.pc
+
+EXTRA_DIST = guichan_sdl2.pc.in

--- a/src/sdl2/guichan_sdl2.pc.in
+++ b/src/sdl2/guichan_sdl2.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=${prefix}/include
+
+Name: guichan_sdl2
+Description: SDL2 extension for the Guichan GUI library
+Version: @VERSION@
+Requires: guichan sdl2
+Conflicts:
+Libs: -L${libdir} -lguichan_sdl2
+Cflags: -I${includedir}

--- a/src/sdl2/sdl2.cpp
+++ b/src/sdl2/sdl2.cpp
@@ -1,0 +1,53 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * For comments regarding functions please see the header file.
+ */
+
+#include "guichan/sdl2.hpp"
+
+extern "C"
+{
+    void gcnSDL2() { }
+}

--- a/src/sdl2/sdl2graphics.cpp
+++ b/src/sdl2/sdl2graphics.cpp
@@ -1,0 +1,276 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * For comments regarding functions please see the header file.
+ */
+
+#include "guichan/sdl2/sdl2graphics.hpp"
+
+#include "guichan/exception.hpp"
+#include "guichan/font.hpp"
+#include "guichan/image.hpp"
+#include "guichan/sdl2/sdl2image.hpp"
+
+namespace gcn
+{
+    SDL2Graphics::SDL2Graphics(SDL_Renderer* renderer)
+    {
+        mRenderer = NULL;
+        setTarget(renderer);
+    }
+
+    void SDL2Graphics::_beginDraw()
+    {
+        if (mRenderer == NULL)
+        {
+            throw GCN_EXCEPTION("No renderer set, call setTarget first.");
+        }
+
+        Rectangle area;
+        area.x = 0;
+        area.y = 0;
+
+        // The logical size is what drawing coordinates refer to when it
+        // has been set, otherwise coordinates are in output pixels.
+        SDL_RenderGetLogicalSize(mRenderer, &area.width, &area.height);
+
+        if (area.width == 0 || area.height == 0)
+        {
+            SDL_GetRendererOutputSize(mRenderer, &area.width, &area.height);
+        }
+
+        SDL_SetRenderDrawBlendMode(mRenderer, SDL_BLENDMODE_BLEND);
+
+        pushClipArea(area);
+    }
+
+    void SDL2Graphics::_endDraw()
+    {
+        popClipArea();
+    }
+
+    void SDL2Graphics::setTarget(SDL_Renderer* renderer)
+    {
+        mRenderer = renderer;
+
+        if (mRenderer != NULL)
+        {
+            SDL_SetRenderDrawBlendMode(mRenderer, SDL_BLENDMODE_BLEND);
+        }
+    }
+
+    SDL_Renderer* SDL2Graphics::getTarget() const
+    {
+        return mRenderer;
+    }
+
+    bool SDL2Graphics::pushClipArea(Rectangle area)
+    {
+        bool result = Graphics::pushClipArea(area);
+        updateClipRect();
+        return result;
+    }
+
+    void SDL2Graphics::popClipArea()
+    {
+        Graphics::popClipArea();
+        updateClipRect();
+    }
+
+    void SDL2Graphics::updateClipRect()
+    {
+        if (mClipStack.empty())
+        {
+            SDL_RenderSetClipRect(mRenderer, NULL);
+            return;
+        }
+
+        const ClipRectangle& carea = mClipStack.top();
+        SDL_Rect rect;
+        rect.x = carea.x;
+        rect.y = carea.y;
+        rect.w = carea.width;
+        rect.h = carea.height;
+
+        SDL_RenderSetClipRect(mRenderer, &rect);
+    }
+
+    void SDL2Graphics::applyColor()
+    {
+        SDL_SetRenderDrawColor(mRenderer,
+                               mColor.r,
+                               mColor.g,
+                               mColor.b,
+                               mColor.a);
+    }
+
+    void SDL2Graphics::drawImage(const Image* image,
+                                 int srcX,
+                                 int srcY,
+                                 int dstX,
+                                 int dstY,
+                                 int width,
+                                 int height)
+    {
+        const SDL2Image* srcImage = dynamic_cast<const SDL2Image*>(image);
+
+        if (srcImage == NULL)
+        {
+            throw GCN_EXCEPTION("Trying to draw an image of unknown format, must be an SDL2Image.");
+        }
+
+        if (srcImage->getTexture() == NULL)
+        {
+            throw GCN_EXCEPTION("Trying to draw an image that has not been converted to display format.");
+        }
+
+        SDL_Rect src;
+        SDL_Rect dst;
+        src.x = srcX;
+        src.y = srcY;
+        src.w = width;
+        src.h = height;
+        dst.x = dstX;
+        dst.y = dstY;
+        dst.w = width;
+        dst.h = height;
+
+        drawSDLTexture(srcImage->getTexture(), src, dst);
+    }
+
+    void SDL2Graphics::drawSDLTexture(SDL_Texture* texture,
+                                      SDL_Rect source,
+                                      SDL_Rect destination)
+    {
+        if (mClipStack.empty())
+        {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+
+        const ClipRectangle& top = mClipStack.top();
+
+        destination.x += top.xOffset;
+        destination.y += top.yOffset;
+
+        SDL_RenderCopy(mRenderer, texture, &source, &destination);
+    }
+
+    void SDL2Graphics::fillRectangle(const Rectangle& rectangle)
+    {
+        if (mClipStack.empty())
+        {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+
+        const ClipRectangle& top = mClipStack.top();
+
+        SDL_Rect rect;
+        rect.x = rectangle.x + top.xOffset;
+        rect.y = rectangle.y + top.yOffset;
+        rect.w = rectangle.width;
+        rect.h = rectangle.height;
+
+        applyColor();
+        SDL_RenderFillRect(mRenderer, &rect);
+    }
+
+    void SDL2Graphics::drawPoint(int x, int y)
+    {
+        if (mClipStack.empty())
+        {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+
+        const ClipRectangle& top = mClipStack.top();
+
+        applyColor();
+        SDL_RenderDrawPoint(mRenderer, x + top.xOffset, y + top.yOffset);
+    }
+
+    void SDL2Graphics::drawLine(int x1, int y1, int x2, int y2)
+    {
+        if (mClipStack.empty())
+        {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+
+        const ClipRectangle& top = mClipStack.top();
+
+        applyColor();
+        SDL_RenderDrawLine(mRenderer,
+                           x1 + top.xOffset,
+                           y1 + top.yOffset,
+                           x2 + top.xOffset,
+                           y2 + top.yOffset);
+    }
+
+    void SDL2Graphics::drawRectangle(const Rectangle& rectangle)
+    {
+        if (mClipStack.empty())
+        {
+            throw GCN_EXCEPTION("Clip stack is empty, perhaps you called a draw function outside of _beginDraw() and _endDraw()?");
+        }
+
+        const ClipRectangle& top = mClipStack.top();
+
+        SDL_Rect rect;
+        rect.x = rectangle.x + top.xOffset;
+        rect.y = rectangle.y + top.yOffset;
+        rect.w = rectangle.width;
+        rect.h = rectangle.height;
+
+        applyColor();
+        SDL_RenderDrawRect(mRenderer, &rect);
+    }
+
+    void SDL2Graphics::setColor(const Color& color)
+    {
+        mColor = color;
+    }
+
+    const Color& SDL2Graphics::getColor() const
+    {
+        return mColor;
+    }
+}

--- a/src/sdl2/sdl2image.cpp
+++ b/src/sdl2/sdl2image.cpp
@@ -1,0 +1,329 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * For comments regarding functions please see the header file.
+ */
+
+#include "guichan/sdl2/sdl2image.hpp"
+
+#include "guichan/exception.hpp"
+
+namespace gcn
+{
+    namespace
+    {
+        /**
+         * Reads a raw pixel value from a pixel buffer.
+         */
+        Uint32 readPixel(const Uint8* p, int bpp)
+        {
+            switch (bpp)
+            {
+              case 1:
+                  return *p;
+
+              case 2:
+                  return *(const Uint16*)p;
+
+              case 3:
+                  if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
+                  {
+                      return p[0] << 16 | p[1] << 8 | p[2];
+                  }
+                  else
+                  {
+                      return p[0] | p[1] << 8 | p[2] << 16;
+                  }
+
+              case 4:
+                  return *(const Uint32*)p;
+
+              default:
+                  return 0;
+            }
+        }
+
+        /**
+         * Writes a raw pixel value to a pixel buffer.
+         */
+        void writePixel(Uint8* p, int bpp, Uint32 pixel)
+        {
+            switch (bpp)
+            {
+              case 1:
+                  *p = pixel;
+                  break;
+
+              case 2:
+                  *(Uint16*)p = pixel;
+                  break;
+
+              case 3:
+                  if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
+                  {
+                      p[0] = (pixel >> 16) & 0xff;
+                      p[1] = (pixel >> 8) & 0xff;
+                      p[2] = pixel & 0xff;
+                  }
+                  else
+                  {
+                      p[0] = pixel & 0xff;
+                      p[1] = (pixel >> 8) & 0xff;
+                      p[2] = (pixel >> 16) & 0xff;
+                  }
+                  break;
+
+              case 4:
+                  *(Uint32*)p = pixel;
+                  break;
+            }
+        }
+
+        /**
+         * Gets a pointer to a pixel of a surface, which must be locked.
+         */
+        Uint8* pixelAddress(SDL_Surface* surface, int x, int y)
+        {
+            return (Uint8*)surface->pixels
+                + y * surface->pitch
+                + x * surface->format->BytesPerPixel;
+        }
+    }
+
+    SDL2Image::SDL2Image(SDL_Surface* surface, SDL_Renderer* renderer, bool autoFree)
+    {
+        mSurface = surface;
+        mTexture = NULL;
+        mRenderer = renderer;
+        mWidth = surface != NULL ? surface->w : 0;
+        mHeight = surface != NULL ? surface->h : 0;
+        mAutoFree = autoFree;
+    }
+
+    SDL2Image::SDL2Image(SDL_Texture* texture, int width, int height, bool autoFree)
+    {
+        mSurface = NULL;
+        mTexture = texture;
+        mRenderer = NULL;
+        mWidth = width;
+        mHeight = height;
+        mAutoFree = autoFree;
+    }
+
+    SDL2Image::~SDL2Image()
+    {
+        if (mAutoFree)
+        {
+            free();
+        }
+    }
+
+    SDL_Surface* SDL2Image::getSurface() const
+    {
+        return mSurface;
+    }
+
+    SDL_Texture* SDL2Image::getTexture() const
+    {
+        return mTexture;
+    }
+
+    int SDL2Image::getWidth() const
+    {
+        if (mSurface == NULL && mTexture == NULL)
+        {
+            throw GCN_EXCEPTION("Trying to get the width of a non loaded image.");
+        }
+
+        return mWidth;
+    }
+
+    int SDL2Image::getHeight() const
+    {
+        if (mSurface == NULL && mTexture == NULL)
+        {
+            throw GCN_EXCEPTION("Trying to get the height of a non loaded image.");
+        }
+
+        return mHeight;
+    }
+
+    Color SDL2Image::getPixel(int x, int y)
+    {
+        if (mTexture != NULL)
+        {
+            throw GCN_EXCEPTION("Image has been converted to display format");
+        }
+
+        if (mSurface == NULL)
+        {
+            throw GCN_EXCEPTION("Trying to get a pixel from a non loaded image.");
+        }
+
+        if (x < 0 || x >= mWidth || y < 0 || y >= mHeight)
+        {
+            throw GCN_EXCEPTION("Coordinates outside of the image");
+        }
+
+        SDL_LockSurface(mSurface);
+
+        Uint32 pixel = readPixel(pixelAddress(mSurface, x, y),
+                                 mSurface->format->BytesPerPixel);
+
+        Uint8 r, g, b, a;
+        SDL_GetRGBA(pixel, mSurface->format, &r, &g, &b, &a);
+
+        SDL_UnlockSurface(mSurface);
+
+        return Color(r, g, b, a);
+    }
+
+    void SDL2Image::putPixel(int x, int y, const Color& color)
+    {
+        if (mTexture != NULL)
+        {
+            throw GCN_EXCEPTION("Image has been converted to display format");
+        }
+
+        if (mSurface == NULL)
+        {
+            throw GCN_EXCEPTION("Trying to put a pixel in a non loaded image.");
+        }
+
+        if (x < 0 || x >= mWidth || y < 0 || y >= mHeight)
+        {
+            throw GCN_EXCEPTION("Coordinates outside of the image");
+        }
+
+        Uint32 pixel = SDL_MapRGBA(mSurface->format,
+                                   color.r, color.g, color.b, color.a);
+
+        SDL_LockSurface(mSurface);
+
+        writePixel(pixelAddress(mSurface, x, y),
+                   mSurface->format->BytesPerPixel,
+                   pixel);
+
+        SDL_UnlockSurface(mSurface);
+    }
+
+    void SDL2Image::convertToDisplayFormat()
+    {
+        if (mTexture != NULL)
+        {
+            throw GCN_EXCEPTION("Image has already been converted to display format");
+        }
+
+        if (mSurface == NULL)
+        {
+            throw GCN_EXCEPTION("Trying to convert a non loaded image to display format.");
+        }
+
+        if (mRenderer == NULL)
+        {
+            throw GCN_EXCEPTION("Trying to convert an image to display format without a renderer.");
+        }
+
+        // Pink is the color key convention of the Guichan image loaders.
+        // SDL_CreateTextureFromSurface turns color keyed pixels into
+        // transparent ones.
+        const Uint32 pink = SDL_MapRGB(mSurface->format, 255, 0, 255);
+        const int bpp = mSurface->format->BytesPerPixel;
+        bool hasPink = false;
+
+        SDL_LockSurface(mSurface);
+
+        for (int y = 0; y < mHeight && !hasPink; ++y)
+        {
+            for (int x = 0; x < mWidth; ++x)
+            {
+                if (readPixel(pixelAddress(mSurface, x, y), bpp) == pink)
+                {
+                    hasPink = true;
+                    break;
+                }
+            }
+        }
+
+        SDL_UnlockSurface(mSurface);
+
+        if (hasPink)
+        {
+            SDL_SetColorKey(mSurface, SDL_TRUE, pink);
+        }
+
+        SDL_Texture* texture = SDL_CreateTextureFromSurface(mRenderer, mSurface);
+
+        if (texture == NULL)
+        {
+            throw GCN_EXCEPTION(std::string("Unable to convert image to display format: ")
+                                + SDL_GetError());
+        }
+
+        SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+
+        if (mAutoFree)
+        {
+            SDL_FreeSurface(mSurface);
+        }
+
+        mSurface = NULL;
+        mTexture = texture;
+    }
+
+    void SDL2Image::free()
+    {
+        if (mSurface != NULL)
+        {
+            SDL_FreeSurface(mSurface);
+            mSurface = NULL;
+        }
+
+        if (mTexture != NULL)
+        {
+            SDL_DestroyTexture(mTexture);
+            mTexture = NULL;
+        }
+    }
+}

--- a/src/sdl2/sdl2imageloader.cpp
+++ b/src/sdl2/sdl2imageloader.cpp
@@ -1,0 +1,111 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * For comments regarding functions please see the header file.
+ */
+
+#include "guichan/sdl2/sdl2image.hpp"
+
+#include "SDL_image.h"
+
+#include "guichan/exception.hpp"
+#include "guichan/sdl2/sdl2imageloader.hpp"
+
+namespace gcn
+{
+    SDL2ImageLoader::SDL2ImageLoader(SDL_Renderer* renderer)
+    {
+        mRenderer = renderer;
+    }
+
+    void SDL2ImageLoader::setRenderer(SDL_Renderer* renderer)
+    {
+        mRenderer = renderer;
+    }
+
+    SDL_Renderer* SDL2ImageLoader::getRenderer() const
+    {
+        return mRenderer;
+    }
+
+    Image* SDL2ImageLoader::load(const std::string& filename,
+                                 bool convertToDisplayFormat)
+    {
+        SDL_Surface *loadedSurface = loadSDLSurface(filename);
+
+        if (loadedSurface == NULL)
+        {
+            throw GCN_EXCEPTION(
+                    std::string("Unable to load image file: ") + filename);
+        }
+
+        SDL_Surface *surface = convertToStandardFormat(loadedSurface);
+        SDL_FreeSurface(loadedSurface);
+
+        if (surface == NULL)
+        {
+            throw GCN_EXCEPTION(
+                    std::string("Not enough memory to load: ") + filename);
+        }
+
+        Image *image = new SDL2Image(surface, mRenderer, true);
+
+        if (convertToDisplayFormat)
+        {
+            image->convertToDisplayFormat();
+        }
+
+        return image;
+    }
+
+    SDL_Surface* SDL2ImageLoader::loadSDLSurface(const std::string& filename)
+    {
+        return IMG_Load(filename.c_str());
+    }
+
+    SDL_Surface* SDL2ImageLoader::convertToStandardFormat(SDL_Surface* surface)
+    {
+        return SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_RGBA32, 0);
+    }
+}

--- a/src/sdl2/sdl2input.cpp
+++ b/src/sdl2/sdl2input.cpp
@@ -1,0 +1,533 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * For comments regarding functions please see the header file.
+ */
+
+#include "guichan/sdl2/sdl2input.hpp"
+
+#include "guichan/exception.hpp"
+
+namespace gcn
+{
+    SDL2Input::SDL2Input()
+    {
+        mMouseInWindow = true;
+        mMouseDown = false;
+        mMouseX = 0;
+        mMouseY = 0;
+    }
+
+    bool SDL2Input::isKeyQueueEmpty()
+    {
+        return mKeyInputQueue.empty();
+    }
+
+    KeyInput SDL2Input::dequeueKeyInput()
+    {
+        KeyInput keyInput;
+
+        if (mKeyInputQueue.empty())
+        {
+            throw GCN_EXCEPTION("The queue is empty.");
+        }
+
+        keyInput = mKeyInputQueue.front();
+        mKeyInputQueue.pop();
+
+        return keyInput;
+    }
+
+    bool SDL2Input::isMouseQueueEmpty()
+    {
+        return mMouseInputQueue.empty();
+    }
+
+    MouseInput SDL2Input::dequeueMouseInput()
+    {
+        MouseInput mouseInput;
+
+        if (mMouseInputQueue.empty())
+        {
+            throw GCN_EXCEPTION("The queue is empty.");
+        }
+
+        mouseInput = mMouseInputQueue.front();
+        mMouseInputQueue.pop();
+
+        return mouseInput;
+    }
+
+    bool SDL2Input::hasTextInput()
+    {
+        return true;
+    }
+
+    bool SDL2Input::isTextQueueEmpty()
+    {
+        return mTextInputQueue.empty();
+    }
+
+    TextInput SDL2Input::dequeueTextInput()
+    {
+        TextInput textInput;
+
+        if (mTextInputQueue.empty())
+        {
+            throw GCN_EXCEPTION("The queue is empty.");
+        }
+
+        textInput = mTextInputQueue.front();
+        mTextInputQueue.pop();
+
+        return textInput;
+    }
+
+    void SDL2Input::pushInput(SDL_Event event)
+    {
+        KeyInput keyInput;
+        MouseInput mouseInput;
+
+        switch (event.type)
+        {
+          case SDL_KEYDOWN:
+          case SDL_KEYUP:
+          {
+              const SDL_Keysym& keysym = event.key.keysym;
+
+              int value = convertSDLEventToGuichanKeyValue(event);
+
+              if (value == -1)
+              {
+                  value = keysym.sym;
+              }
+
+              keyInput.setKey(Key(value));
+              keyInput.setType(event.type == SDL_KEYDOWN ? KeyInput::Pressed
+                                                         : KeyInput::Released);
+              keyInput.setShiftPressed((keysym.mod & KMOD_SHIFT) != 0);
+              keyInput.setControlPressed((keysym.mod & KMOD_CTRL) != 0);
+              keyInput.setAltPressed((keysym.mod & KMOD_ALT) != 0);
+              keyInput.setMetaPressed((keysym.mod & KMOD_GUI) != 0);
+              keyInput.setNumericPad(isNumericPadKey(keysym.scancode));
+
+              mKeyInputQueue.push(keyInput);
+              break;
+          }
+
+          case SDL_TEXTINPUT:
+              mTextInputQueue.push(TextInput(event.text.text));
+              break;
+
+          case SDL_MOUSEBUTTONDOWN:
+              mMouseDown = true;
+              mMouseX = event.button.x;
+              mMouseY = event.button.y;
+              mouseInput.setX(event.button.x);
+              mouseInput.setY(event.button.y);
+              mouseInput.setButton(convertMouseButton(event.button.button));
+              mouseInput.setType(MouseInput::Pressed);
+              mouseInput.setTimeStamp(event.button.timestamp);
+              mMouseInputQueue.push(mouseInput);
+              break;
+
+          case SDL_MOUSEBUTTONUP:
+              mMouseDown = false;
+              mMouseX = event.button.x;
+              mMouseY = event.button.y;
+              mouseInput.setX(event.button.x);
+              mouseInput.setY(event.button.y);
+              mouseInput.setButton(convertMouseButton(event.button.button));
+              mouseInput.setType(MouseInput::Released);
+              mouseInput.setTimeStamp(event.button.timestamp);
+              mMouseInputQueue.push(mouseInput);
+              break;
+
+          case SDL_MOUSEMOTION:
+              mMouseX = event.motion.x;
+              mMouseY = event.motion.y;
+              mouseInput.setX(event.motion.x);
+              mouseInput.setY(event.motion.y);
+              mouseInput.setButton(MouseInput::Empty);
+              mouseInput.setType(MouseInput::Moved);
+              mouseInput.setTimeStamp(event.motion.timestamp);
+              mMouseInputQueue.push(mouseInput);
+              break;
+
+          case SDL_MOUSEWHEEL:
+          {
+              /*
+               * The wheel event has no position before SDL 2.26, so the
+               * position of the last mouse event is used. The direction of
+               * the y value already follows the user's system preference,
+               * so no correction for SDL_MOUSEWHEEL_FLIPPED is made. Scroll
+               * amounts below one step, as reported by some touchpads, are
+               * ignored.
+               */
+              int x = mMouseX;
+              int y = mMouseY;
+#if SDL_VERSION_ATLEAST(2, 26, 0)
+              x = event.wheel.mouseX;
+              y = event.wheel.mouseY;
+#endif
+              int steps = event.wheel.y;
+
+              mouseInput.setX(x);
+              mouseInput.setY(y);
+              mouseInput.setButton(MouseInput::Empty);
+              mouseInput.setType(steps > 0 ? MouseInput::WheelMovedUp
+                                           : MouseInput::WheelMovedDown);
+              mouseInput.setTimeStamp(event.wheel.timestamp);
+
+              for (steps = steps < 0 ? -steps : steps; steps > 0; --steps)
+              {
+                  mMouseInputQueue.push(mouseInput);
+              }
+              break;
+          }
+
+          case SDL_WINDOWEVENT:
+              /*
+               * This occurs when the mouse leaves the window and the Gui-chan
+               * application loses its mousefocus.
+               */
+              if (event.window.event == SDL_WINDOWEVENT_LEAVE)
+              {
+                  mMouseInWindow = false;
+
+                  if (!mMouseDown)
+                  {
+                      mouseInput.setX(-1);
+                      mouseInput.setY(-1);
+                      mouseInput.setButton(MouseInput::Empty);
+                      mouseInput.setType(MouseInput::Moved);
+                      mouseInput.setTimeStamp(event.window.timestamp);
+                      mMouseInputQueue.push(mouseInput);
+                  }
+              }
+              else if (event.window.event == SDL_WINDOWEVENT_ENTER)
+              {
+                  mMouseInWindow = true;
+              }
+              break;
+
+        } // end switch
+    }
+
+    int SDL2Input::convertMouseButton(int button)
+    {
+        switch (button)
+        {
+          case SDL_BUTTON_LEFT:
+              return MouseInput::Left;
+              break;
+          case SDL_BUTTON_RIGHT:
+              return MouseInput::Right;
+              break;
+          case SDL_BUTTON_MIDDLE:
+              return MouseInput::Middle;
+              break;
+          default:
+              // We have an unknown mouse type which is ignored.
+              return button;
+        }
+    }
+
+    bool SDL2Input::isNumericPadKey(SDL_Scancode scancode)
+    {
+        return (scancode >= SDL_SCANCODE_KP_DIVIDE
+                && scancode <= SDL_SCANCODE_KP_PERIOD)
+            || scancode == SDL_SCANCODE_KP_EQUALS
+            || scancode == SDL_SCANCODE_KP_COMMA
+            || scancode == SDL_SCANCODE_KP_EQUALSAS400
+            || (scancode >= SDL_SCANCODE_KP_00
+                && scancode <= SDL_SCANCODE_KP_HEXADECIMAL);
+    }
+
+    int SDL2Input::convertSDLEventToGuichanKeyValue(SDL_Event event)
+    {
+        int value = -1;
+
+        switch (event.key.keysym.sym)
+        {
+          case SDLK_TAB:
+              value = Key::Tab;
+              break;
+          case SDLK_LALT:
+              value = Key::LeftAlt;
+              break;
+          case SDLK_RALT:
+              value = Key::RightAlt;
+              break;
+          case SDLK_LSHIFT:
+              value = Key::LeftShift;
+              break;
+          case SDLK_RSHIFT:
+              value = Key::RightShift;
+              break;
+          case SDLK_LCTRL:
+              value = Key::LeftControl;
+              break;
+          case SDLK_RCTRL:
+              value = Key::RightControl;
+              break;
+          case SDLK_BACKSPACE:
+              value = Key::Backspace;
+              break;
+          case SDLK_PAUSE:
+              value = Key::Pause;
+              break;
+          case SDLK_SPACE:
+              value = Key::Space;
+              break;
+          case SDLK_ESCAPE:
+              value = Key::Escape;
+              break;
+          case SDLK_DELETE:
+              value = Key::Delete;
+              break;
+          case SDLK_INSERT:
+              value = Key::Insert;
+              break;
+          case SDLK_HOME:
+              value = Key::Home;
+              break;
+          case SDLK_END:
+              value = Key::End;
+              break;
+          case SDLK_PAGEUP:
+              value = Key::PageUp;
+              break;
+          case SDLK_PRINTSCREEN:
+              value = Key::PrintScreen;
+              break;
+          case SDLK_PAGEDOWN:
+              value = Key::PageDown;
+              break;
+          case SDLK_F1:
+              value = Key::F1;
+              break;
+          case SDLK_F2:
+              value = Key::F2;
+              break;
+          case SDLK_F3:
+              value = Key::F3;
+              break;
+          case SDLK_F4:
+              value = Key::F4;
+              break;
+          case SDLK_F5:
+              value = Key::F5;
+              break;
+          case SDLK_F6:
+              value = Key::F6;
+              break;
+          case SDLK_F7:
+              value = Key::F7;
+              break;
+          case SDLK_F8:
+              value = Key::F8;
+              break;
+          case SDLK_F9:
+              value = Key::F9;
+              break;
+          case SDLK_F10:
+              value = Key::F10;
+              break;
+          case SDLK_F11:
+              value = Key::F11;
+              break;
+          case SDLK_F12:
+              value = Key::F12;
+              break;
+          case SDLK_F13:
+              value = Key::F13;
+              break;
+          case SDLK_F14:
+              value = Key::F14;
+              break;
+          case SDLK_F15:
+              value = Key::F15;
+              break;
+          case SDLK_NUMLOCKCLEAR:
+              value = Key::NumLock;
+              break;
+          case SDLK_CAPSLOCK:
+              value = Key::CapsLock;
+              break;
+          case SDLK_SCROLLLOCK:
+              value = Key::ScrollLock;
+              break;
+          case SDLK_LGUI:
+              value = Key::LeftMeta;
+              break;
+          case SDLK_RGUI:
+              value = Key::RightMeta;
+              break;
+          case SDLK_MODE:
+              value = Key::AltGr;
+              break;
+          case SDLK_UP:
+              value = Key::Up;
+              break;
+          case SDLK_DOWN:
+              value = Key::Down;
+              break;
+          case SDLK_LEFT:
+              value = Key::Left;
+              break;
+          case SDLK_RIGHT:
+              value = Key::Right;
+              break;
+          case SDLK_RETURN:
+              value = Key::Enter;
+              break;
+          case SDLK_KP_ENTER:
+              value = Key::Enter;
+              break;
+          case SDLK_KP_DIVIDE:
+              value = '/';
+              break;
+          case SDLK_KP_MULTIPLY:
+              value = '*';
+              break;
+          case SDLK_KP_MINUS:
+              value = '-';
+              break;
+          case SDLK_KP_PLUS:
+              value = '+';
+              break;
+          case SDLK_KP_EQUALS:
+              value = '=';
+              break;
+
+          default:
+              break;
+        }
+
+        // With num lock on the numeric pad produces digits, with num lock
+        // off it acts as navigation keys.
+        if (event.key.keysym.mod & KMOD_NUM)
+        {
+            switch (event.key.keysym.sym)
+            {
+              case SDLK_KP_0:
+                  value = '0';
+                  break;
+              case SDLK_KP_1:
+                  value = '1';
+                  break;
+              case SDLK_KP_2:
+                  value = '2';
+                  break;
+              case SDLK_KP_3:
+                  value = '3';
+                  break;
+              case SDLK_KP_4:
+                  value = '4';
+                  break;
+              case SDLK_KP_5:
+                  value = '5';
+                  break;
+              case SDLK_KP_6:
+                  value = '6';
+                  break;
+              case SDLK_KP_7:
+                  value = '7';
+                  break;
+              case SDLK_KP_8:
+                  value = '8';
+                  break;
+              case SDLK_KP_9:
+                  value = '9';
+                  break;
+              case SDLK_KP_PERIOD:
+                  value = '.';
+                  break;
+              default:
+                  break;
+            }
+        }
+        else
+        {
+            switch (event.key.keysym.sym)
+            {
+              case SDLK_KP_0:
+                  value = Key::Insert;
+                  break;
+              case SDLK_KP_1:
+                  value = Key::End;
+                  break;
+              case SDLK_KP_2:
+                  value = Key::Down;
+                  break;
+              case SDLK_KP_3:
+                  value = Key::PageDown;
+                  break;
+              case SDLK_KP_4:
+                  value = Key::Left;
+                  break;
+              case SDLK_KP_6:
+                  value = Key::Right;
+                  break;
+              case SDLK_KP_7:
+                  value = Key::Home;
+                  break;
+              case SDLK_KP_8:
+                  value = Key::Up;
+                  break;
+              case SDLK_KP_9:
+                  value = Key::PageUp;
+                  break;
+              case SDLK_KP_PERIOD:
+                  value = Key::Delete;
+                  break;
+              default:
+                  break;
+            }
+        }
+
+        return value;
+    }
+}


### PR DESCRIPTION
Adds an SDL2 extension (`guichan_sdl2`) as a sibling of the SDL 1.2 one. Draft, up for review.

Stacked on the text work: #26 (`text-utf8`) then #28 (`text-input-events`) then this PR, so the diff here only makes sense against `text-input-events`.

Design:

- Graphics: `SDL2Graphics(SDL_Renderer*)` draws with `SDL_Render*` calls. `pushClipArea`/`popClipArea` call the base and apply the top of the clip stack through `SDL_RenderSetClipRect` (removed again when the stack is empty), the draw blend mode is `SDL_BLENDMODE_BLEND` so alpha in the current color works, and `drawImage` uses `SDL_RenderCopy` with the image's texture. The application clears and presents the renderer around `Gui::draw()`.
- Images: `SDL2Image` holds an `SDL_Surface` after loading and an `SDL_Texture` after `convertToDisplayFormat()`, which creates the texture for the renderer given to `SDL2ImageLoader(SDL_Renderer*)`, sets `SDL_BLENDMODE_BLEND`, turns pink into transparency through a color key and frees the surface. `getPixel`/`putPixel` work on the surface before conversion and throw afterwards, so pixel reading users like `ImageFont` load with `convertToDisplayFormat = false`. An `SDL2Image` can also wrap an existing texture.
- Input: every `SDL_KEYDOWN`/`SDL_KEYUP` becomes a `KeyInput`, with the `Key` constants for keys that do not produce text and the SDL key code otherwise (so Ctrl+V is `'v'` with `isControlPressed()`), like the 1.2 backend. `SDL_TEXTINPUT` pushes one `TextInput` holding the UTF-8 string onto the text queue and `hasTextInput()` returns true, so the `Gui` distributes text events and never derives text from key presses. The application calls `SDL_StartTextInput()`; `SDL_TEXTEDITING` composition is not delivered. `SDL_MOUSEWHEEL` maps to `WheelMovedUp`/`WheelMovedDown`, `SDL_WINDOWEVENT_LEAVE` replaces the `SDL_ACTIVEEVENT` handling.
- Build: `ENABLE_SDL2` CMake option (on by default when the SDL2 and SDL2_image CMake configs are found), pkg-config file, autotools support so `make distcheck` ships it, SDL2 variants of the hello world and widgets examples using a window plus renderer, and SDL2 packages in CI.
