### PR TITLE
Add text input events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,10 @@ file(
   include/guichan/rectangle.hpp
   include/guichan/selectionevent.hpp
   include/guichan/selectionlistener.hpp
+  include/guichan/text.hpp
+  include/guichan/textevent.hpp
+  include/guichan/textinput.hpp
+  include/guichan/textlistener.hpp
   include/guichan/widget.hpp
   include/guichan/widgetlistener.hpp)
 file(GLOB GUICHAN_WIDGET_HEADERS include/guichan/widgets/*.hpp)

--- a/include/guichan/Makefile.am
+++ b/include/guichan/Makefile.am
@@ -54,6 +54,9 @@ libguichaninclude_HEADERS =	\
 	selectionlistener.hpp	\
 	sdl.hpp			\
 	text.hpp		\
+	textevent.hpp		\
+	textinput.hpp		\
+	textlistener.hpp	\
 	widget.hpp		\
 	widgetlistener.hpp
 

--- a/include/guichan/gui.hpp
+++ b/include/guichan/gui.hpp
@@ -51,6 +51,7 @@
 #include "guichan/mouseevent.hpp"
 #include "guichan/mouseinput.hpp"
 #include "guichan/platform.hpp"
+#include "guichan/textevent.hpp"
 
 namespace gcn
 {
@@ -86,7 +87,17 @@ namespace gcn
      *       able to load images an implementation of ImageLoader must be
      *       passed to Image.
      *
-     * @see Graphics, Input, Image
+     * Entered text reaches widgets as text events, separately from key
+     * events. A back end with native text input, such as one built on a
+     * library that reports entered text as UTF-8 strings, sets
+     * Input::hasTextInput to true and delivers whole strings through the
+     * text queue of its Input. For any other back end the Gui synthesises
+     * a text event from each pressed key that represents a character,
+     * as long as the key was not consumed by a key listener, it is not
+     * Tab, and none of control, alt or meta is held. See handleKeyInput
+     * and handleTextInput.
+     *
+     * @see Graphics, Input, Image, TextListener
      */
     class GCN_CORE_DECLSPEC Gui
     {
@@ -243,11 +254,26 @@ namespace gcn
         virtual void handleMouseInput();
 
         /**
-         * Handles key input.
+         * Handles key input. When the input back end has no native text
+         * input, a pressed key that represents a character and was not
+         * consumed by any key listener is also distributed as a text
+         * event to the focused widget, unless the key is Tab or control,
+         * alt or meta is held.
          *
+         * @see Input::hasTextInput
          * @since 0.6.0
          */
         virtual void handleKeyInput();
+
+        /**
+         * Handles text input. Every text input in the text queue of the
+         * input back end is distributed as a text event to the focused
+         * widget.
+         *
+         * @see Input::hasTextInput
+         * @since 0.9.0
+         */
+        virtual void handleTextInput();
 
         /**
          * Handles mouse moved input.
@@ -368,6 +394,16 @@ namespace gcn
          * @since 0.6.0
          */
         virtual void distributeKeyEventToGlobalKeyListeners(KeyEvent& keyEvent);
+
+        /**
+         * Distributes a text event. The event is sent to the text
+         * listeners of the source widget and then up the chain of parents
+         * until it has been consumed.
+         *
+         * @param textEvent The text event to distribute.
+         * @since 0.9.0
+         */
+        virtual void distributeTextEvent(TextEvent& textEvent);
 
         /**
          * Gets the widget at a certain position.

--- a/include/guichan/input.hpp
+++ b/include/guichan/input.hpp
@@ -50,6 +50,7 @@ namespace gcn
 {
     class KeyInput;
     class MouseInput;
+    class TextInput;
 
     /**
      * Abstract class for providing functions for user input. 
@@ -101,6 +102,45 @@ namespace gcn
          * @return The first mouse input in the mouse input queue.
          */
         virtual MouseInput dequeueMouseInput() = 0;
+
+        /**
+         * Checks if the back end delivers entered text through the text
+         * queue. When it does, the Gui distributes the dequeued text as
+         * text events and does not derive any text from key events.
+         * When it does not, the Gui synthesises a text event from each
+         * pressed key that represents a character.
+         *
+         * The default implementation returns false, so existing back ends
+         * keep working without changes.
+         *
+         * @return True if entered text is delivered through the text
+         *         queue, false otherwise.
+         * @see isTextQueueEmpty, dequeueTextInput, Gui::handleTextInput
+         * @since 0.9.0
+         */
+        virtual bool hasTextInput();
+
+        /**
+         * Checks if the text queue is empty, or not. The default
+         * implementation always reports an empty queue.
+         *
+         * @return True if the text queue is empty,
+         *         false otherwise.
+         * @see hasTextInput
+         * @since 0.9.0
+         */
+        virtual bool isTextQueueEmpty();
+
+        /**
+         * Dequeues the text input queue. The default implementation
+         * throws as its queue is always empty.
+         *
+         * @return The first text input in the text input queue.
+         * @throws Exception when the text queue is empty.
+         * @see hasTextInput
+         * @since 0.9.0
+         */
+        virtual TextInput dequeueTextInput();
 
         /**
          * Polls all exsisting input. Called when input should

--- a/include/guichan/text.hpp
+++ b/include/guichan/text.hpp
@@ -410,6 +410,16 @@ namespace gcn
         static unsigned int getNextCharacterColumn(const std::string& row,
                                                    unsigned int column);
 
+        /**
+         * Encodes a Unicode code point as UTF-8. Values outside of the
+         * range 0 to 0x10FFFF result in an empty string.
+         *
+         * @param character The Unicode code point to encode.
+         * @return The UTF-8 encoding of the code point.
+         * @since 0.9.0
+         */
+        static std::string encodeUtf8(int character);
+
     protected:
 
         /**

--- a/include/guichan/textevent.hpp
+++ b/include/guichan/textevent.hpp
@@ -41,77 +41,67 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GCN_GUICHAN_HPP
-#define GCN_GUICHAN_HPP
+#ifndef GCN_TEXTEVENT_HPP
+#define GCN_TEXTEVENT_HPP
 
-#include <guichan/actionevent.hpp>
-#include <guichan/actionlistener.hpp>
-#include <guichan/cliprectangle.hpp>
-#include <guichan/color.hpp>
-#include <guichan/containerevent.hpp>
-#include <guichan/containerlistener.hpp>
-#include <guichan/deathlistener.hpp>
-#include <guichan/event.hpp>
-#include <guichan/exception.hpp>
-#include <guichan/focushandler.hpp>
-#include <guichan/focuslistener.hpp>
-#include <guichan/font.hpp>
-#include <guichan/genericinput.hpp>
-#include <guichan/graphics.hpp>
-#include <guichan/gui.hpp>
-#include <guichan/image.hpp>
-#include <guichan/imagefont.hpp>
-#include <guichan/imageloader.hpp>
-#include <guichan/input.hpp>
-#include <guichan/inputevent.hpp>
-#include <guichan/key.hpp>
-#include <guichan/keyevent.hpp>
-#include <guichan/keyinput.hpp>
-#include <guichan/keylistener.hpp>
-#include <guichan/listmodel.hpp>
-#include <guichan/mouseevent.hpp>
-#include <guichan/mouseinput.hpp>
-#include <guichan/mouselistener.hpp>
-#include <guichan/rectangle.hpp>
-#include <guichan/selectionevent.hpp>
-#include <guichan/selectionlistener.hpp>
-#include <guichan/text.hpp>
-#include <guichan/textevent.hpp>
-#include <guichan/textinput.hpp>
-#include <guichan/textlistener.hpp>
-#include <guichan/widget.hpp>
-#include <guichan/widgetlistener.hpp>
-#include <guichan/widgets/button.hpp>
-#include <guichan/widgets/checkbox.hpp>
-#include <guichan/widgets/container.hpp>
-#include <guichan/widgets/dropdown.hpp>
-#include <guichan/widgets/icon.hpp>
-#include <guichan/widgets/imagebutton.hpp>
-#include <guichan/widgets/label.hpp>
-#include <guichan/widgets/listbox.hpp>
-#include <guichan/widgets/scrollarea.hpp>
-#include <guichan/widgets/slider.hpp>
-#include <guichan/widgets/radiobutton.hpp>
-#include <guichan/widgets/tab.hpp>
-#include <guichan/widgets/tabbedarea.hpp>
-#include <guichan/widgets/textbox.hpp>
-#include <guichan/widgets/textfield.hpp>
-#include <guichan/widgets/window.hpp>
-
+#include "guichan/inputevent.hpp"
 #include "guichan/platform.hpp"
 
+#include <string>
 
-class Widget;
-
-extern "C"
+namespace gcn
 {
+    class Widget;
+
     /**
-     * Gets the the version of Guichan. As it is a C function
-     * it can be used to check for Guichan with autotools.
+     * Represents a text event. A text event carries text entered by the
+     * user, as opposed to a KeyEvent which describes a single key going
+     * down or up. The text is UTF-8 encoded and may hold more than one
+     * character.
      *
-     * @return the version of Guichan.
+     * @see TextListener, Widget::addTextListener
+     * @since 0.9.0
      */
-    GCN_CORE_DECLSPEC extern const char* gcnGuichanVersion();
+    class GCN_CORE_DECLSPEC TextEvent: public InputEvent
+    {
+    public:
+        /**
+         * Constructor.
+         *
+         * @param source The widget the event concerns.
+         * @param distributor The distributor of the event.
+         * @param isShiftPressed True if shift is pressed, false otherwise.
+         * @param isControlPressed True if control is pressed, false otherwise.
+         * @param isAltPressed True if alt is pressed, false otherwise.
+         * @param isMetaPressed True if meta is pressed, false otherwise.
+         * @param text The UTF-8 encoded text of the event.
+         */
+        TextEvent(Widget* source,
+                  Widget* distributor,
+                  bool isShiftPressed,
+                  bool isControlPressed,
+                  bool isAltPressed,
+                  bool isMetaPressed,
+                  const std::string& text);
+
+        /**
+         * Destructor.
+         */
+        virtual ~TextEvent();
+
+        /**
+         * Gets the text of the event.
+         *
+         * @return The UTF-8 encoded text of the event.
+         */
+        const std::string& getText() const;
+
+    protected:
+        /**
+         * Holds the text of the text event.
+         */
+        std::string mText;
+    };
 }
 
-#endif // end GCN_GUICHAN_HPP
+#endif // end GCN_TEXTEVENT_HPP

--- a/include/guichan/textinput.hpp
+++ b/include/guichan/textinput.hpp
@@ -41,77 +41,64 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GCN_GUICHAN_HPP
-#define GCN_GUICHAN_HPP
-
-#include <guichan/actionevent.hpp>
-#include <guichan/actionlistener.hpp>
-#include <guichan/cliprectangle.hpp>
-#include <guichan/color.hpp>
-#include <guichan/containerevent.hpp>
-#include <guichan/containerlistener.hpp>
-#include <guichan/deathlistener.hpp>
-#include <guichan/event.hpp>
-#include <guichan/exception.hpp>
-#include <guichan/focushandler.hpp>
-#include <guichan/focuslistener.hpp>
-#include <guichan/font.hpp>
-#include <guichan/genericinput.hpp>
-#include <guichan/graphics.hpp>
-#include <guichan/gui.hpp>
-#include <guichan/image.hpp>
-#include <guichan/imagefont.hpp>
-#include <guichan/imageloader.hpp>
-#include <guichan/input.hpp>
-#include <guichan/inputevent.hpp>
-#include <guichan/key.hpp>
-#include <guichan/keyevent.hpp>
-#include <guichan/keyinput.hpp>
-#include <guichan/keylistener.hpp>
-#include <guichan/listmodel.hpp>
-#include <guichan/mouseevent.hpp>
-#include <guichan/mouseinput.hpp>
-#include <guichan/mouselistener.hpp>
-#include <guichan/rectangle.hpp>
-#include <guichan/selectionevent.hpp>
-#include <guichan/selectionlistener.hpp>
-#include <guichan/text.hpp>
-#include <guichan/textevent.hpp>
-#include <guichan/textinput.hpp>
-#include <guichan/textlistener.hpp>
-#include <guichan/widget.hpp>
-#include <guichan/widgetlistener.hpp>
-#include <guichan/widgets/button.hpp>
-#include <guichan/widgets/checkbox.hpp>
-#include <guichan/widgets/container.hpp>
-#include <guichan/widgets/dropdown.hpp>
-#include <guichan/widgets/icon.hpp>
-#include <guichan/widgets/imagebutton.hpp>
-#include <guichan/widgets/label.hpp>
-#include <guichan/widgets/listbox.hpp>
-#include <guichan/widgets/scrollarea.hpp>
-#include <guichan/widgets/slider.hpp>
-#include <guichan/widgets/radiobutton.hpp>
-#include <guichan/widgets/tab.hpp>
-#include <guichan/widgets/tabbedarea.hpp>
-#include <guichan/widgets/textbox.hpp>
-#include <guichan/widgets/textfield.hpp>
-#include <guichan/widgets/window.hpp>
+#ifndef GCN_TEXTINPUT_HPP
+#define GCN_TEXTINPUT_HPP
 
 #include "guichan/platform.hpp"
 
+#include <string>
 
-class Widget;
-
-extern "C"
+namespace gcn
 {
     /**
-     * Gets the the version of Guichan. As it is a C function
-     * it can be used to check for Guichan with autotools.
+     * Internal class that represents text input. Generally you won't have to
+     * bother using this class unless you implement an Input class for
+     * a back end that delivers entered text separately from key presses.
      *
-     * @return the version of Guichan.
+     * The text is UTF-8 encoded and may hold more than one character, for
+     * instance when it comes from an input method or a paste.
+     *
+     * @see Input::dequeueTextInput
+     * @since 0.9.0
      */
-    GCN_CORE_DECLSPEC extern const char* gcnGuichanVersion();
+    class GCN_CORE_DECLSPEC TextInput
+    {
+    public:
+
+        /**
+         * Constructor.
+         */
+        TextInput() { }
+
+        /**
+         * Constructor.
+         *
+         * @param text The UTF-8 encoded text of the text input.
+         */
+        TextInput(const std::string& text);
+
+        /**
+         * Sets the text of the text input.
+         *
+         * @param text The UTF-8 encoded text of the text input.
+         * @see getText
+         */
+        void setText(const std::string& text);
+
+        /**
+         * Gets the text of the text input.
+         *
+         * @return The UTF-8 encoded text of the text input.
+         * @see setText
+         */
+        const std::string& getText() const;
+
+    protected:
+        /**
+         * Holds the text of the text input.
+         */
+        std::string mText;
+    };
 }
 
-#endif // end GCN_GUICHAN_HPP
+#endif // end GCN_TEXTINPUT_HPP

--- a/include/guichan/textlistener.hpp
+++ b/include/guichan/textlistener.hpp
@@ -41,77 +41,48 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GCN_GUICHAN_HPP
-#define GCN_GUICHAN_HPP
-
-#include <guichan/actionevent.hpp>
-#include <guichan/actionlistener.hpp>
-#include <guichan/cliprectangle.hpp>
-#include <guichan/color.hpp>
-#include <guichan/containerevent.hpp>
-#include <guichan/containerlistener.hpp>
-#include <guichan/deathlistener.hpp>
-#include <guichan/event.hpp>
-#include <guichan/exception.hpp>
-#include <guichan/focushandler.hpp>
-#include <guichan/focuslistener.hpp>
-#include <guichan/font.hpp>
-#include <guichan/genericinput.hpp>
-#include <guichan/graphics.hpp>
-#include <guichan/gui.hpp>
-#include <guichan/image.hpp>
-#include <guichan/imagefont.hpp>
-#include <guichan/imageloader.hpp>
-#include <guichan/input.hpp>
-#include <guichan/inputevent.hpp>
-#include <guichan/key.hpp>
-#include <guichan/keyevent.hpp>
-#include <guichan/keyinput.hpp>
-#include <guichan/keylistener.hpp>
-#include <guichan/listmodel.hpp>
-#include <guichan/mouseevent.hpp>
-#include <guichan/mouseinput.hpp>
-#include <guichan/mouselistener.hpp>
-#include <guichan/rectangle.hpp>
-#include <guichan/selectionevent.hpp>
-#include <guichan/selectionlistener.hpp>
-#include <guichan/text.hpp>
-#include <guichan/textevent.hpp>
-#include <guichan/textinput.hpp>
-#include <guichan/textlistener.hpp>
-#include <guichan/widget.hpp>
-#include <guichan/widgetlistener.hpp>
-#include <guichan/widgets/button.hpp>
-#include <guichan/widgets/checkbox.hpp>
-#include <guichan/widgets/container.hpp>
-#include <guichan/widgets/dropdown.hpp>
-#include <guichan/widgets/icon.hpp>
-#include <guichan/widgets/imagebutton.hpp>
-#include <guichan/widgets/label.hpp>
-#include <guichan/widgets/listbox.hpp>
-#include <guichan/widgets/scrollarea.hpp>
-#include <guichan/widgets/slider.hpp>
-#include <guichan/widgets/radiobutton.hpp>
-#include <guichan/widgets/tab.hpp>
-#include <guichan/widgets/tabbedarea.hpp>
-#include <guichan/widgets/textbox.hpp>
-#include <guichan/widgets/textfield.hpp>
-#include <guichan/widgets/window.hpp>
+#ifndef GCN_TEXTLISTENER_HPP
+#define GCN_TEXTLISTENER_HPP
 
 #include "guichan/platform.hpp"
+#include "guichan/textevent.hpp"
 
-
-class Widget;
-
-extern "C"
+namespace gcn
 {
     /**
-     * Gets the the version of Guichan. As it is a C function
-     * it can be used to check for Guichan with autotools.
+     * Interface for listening for text events from widgets. Text events
+     * carry the text the user entered while the widget had keyboard
+     * focus, which is what a widget should insert instead of interpreting
+     * the values of key events.
      *
-     * @return the version of Guichan.
+     * @see Widget::addTextListener, Widget::removeTextListener
+     * @since 0.9.0
      */
-    GCN_CORE_DECLSPEC extern const char* gcnGuichanVersion();
+    class GCN_CORE_DECLSPEC TextListener
+    {
+    public:
+
+        /**
+         * Destructor.
+         */
+        virtual ~TextListener() { }
+
+        /**
+         * Called when text is entered while the widget has keyboard focus.
+         *
+         * @param textEvent Describes the event.
+         */
+        virtual void textInput(TextEvent& textEvent) { }
+
+    protected:
+        /**
+         * Constructor.
+         *
+         * You should not be able to make an instance of TextListener,
+         * therefore its constructor is protected.
+         */
+        TextListener() { }
+    };
 }
 
-#endif // end GCN_GUICHAN_HPP
+#endif // end GCN_TEXTLISTENER_HPP

--- a/include/guichan/widget.hpp
+++ b/include/guichan/widget.hpp
@@ -61,6 +61,7 @@ namespace gcn
     class Graphics;
     class KeyInput;
     class KeyListener;
+    class TextListener;
     class MouseInput;
     class MouseListener;
     class WidgetListener;
@@ -608,6 +609,26 @@ namespace gcn
         void removeKeyListener(KeyListener* keyListener);
 
         /**
+         * Adds a text listener to the widget. When a text event is
+         * fired by the widget the text listeners of the widget will
+         * get notified.
+         *
+         * @param textListener The text listener to add.
+         * @see removeTextListener
+         * @since 0.9.0
+         */
+        void addTextListener(TextListener* textListener);
+
+        /**
+         * Removes an added text listener from the widget.
+         *
+         * @param textListener The text listener to remove.
+         * @see addTextListener
+         * @since 0.9.0
+         */
+        void removeTextListener(TextListener* textListener);
+
+        /**
          * Adds a focus listener to the widget. When a focus event is 
          * fired by the widget the key listeners of the widget will 
          * get notified.
@@ -894,6 +915,14 @@ namespace gcn
         virtual const std::list<KeyListener*>& _getKeyListeners();
 
         /**
+         * Gets the text listeners of the widget.
+         *
+         * @return The text listeners of the widget.
+         * @since 0.9.0
+         */
+        virtual const std::list<TextListener*>& _getTextListeners();
+
+        /**
          * Gets the focus listeners of the widget.
          *
          * @return The focus listeners of the widget.
@@ -1141,6 +1170,11 @@ namespace gcn
          * Holds the key listeners of the widget.
          */
         std::list<KeyListener*> mKeyListeners;
+
+        /**
+         * Holds the text listeners of the widget.
+         */
+        std::list<TextListener*> mTextListeners;
 
         /** 
          * Holds the action listeners of the widget.

--- a/include/guichan/widgets/textbox.hpp
+++ b/include/guichan/widgets/textbox.hpp
@@ -52,6 +52,7 @@
 #include "guichan/mouselistener.hpp"
 #include "guichan/platform.hpp"
 #include "guichan/text.hpp"
+#include "guichan/textlistener.hpp"
 #include "guichan/widget.hpp"
 
 namespace gcn
@@ -62,7 +63,8 @@ namespace gcn
     class GCN_CORE_DECLSPEC TextBox:
         public Widget,
         public MouseListener,
-        public KeyListener
+        public KeyListener,
+        public TextListener
     {
     public:
         /**
@@ -260,6 +262,11 @@ namespace gcn
         // Inherited from KeyListener
 
         virtual void keyPressed(KeyEvent& keyEvent);
+
+
+        // Inherited from TextListener
+
+        virtual void textInput(TextEvent& textEvent);
 
 
         // Inherited from MouseListener

--- a/include/guichan/widgets/textfield.hpp
+++ b/include/guichan/widgets/textfield.hpp
@@ -48,6 +48,7 @@
 #include "guichan/mouselistener.hpp"
 #include "guichan/platform.hpp"
 #include "guichan/text.hpp"
+#include "guichan/textlistener.hpp"
 #include "guichan/widget.hpp"
 
 #include <string>
@@ -60,7 +61,8 @@ namespace gcn
     class GCN_CORE_DECLSPEC TextField:
         public Widget,
         public MouseListener,
-        public KeyListener
+        public KeyListener,
+        public TextListener
     {
     public:
         /**
@@ -176,6 +178,11 @@ namespace gcn
         // Inherited from KeyListener
 
         virtual void keyPressed(KeyEvent& keyEvent);
+
+
+        // Inherited from TextListener
+
+        virtual void textInput(TextEvent& textEvent);
 
     protected:
         /**

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,7 @@ libguichan_la_SOURCES = 	\
 	guichan.cpp		\
 	image.cpp		\
 	imagefont.cpp		\
+	input.cpp		\
 	inputevent.cpp		\
 	key.cpp			\
 	keyevent.cpp		\
@@ -52,4 +53,6 @@ libguichan_la_SOURCES = 	\
 	rectangle.cpp		\
 	selectionevent.cpp	\
 	text.cpp		\
+	textevent.cpp		\
+	textinput.cpp		\
 	widget.cpp

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -55,6 +55,9 @@
 #include "guichan/keylistener.hpp"
 #include "guichan/mouseinput.hpp"
 #include "guichan/mouselistener.hpp"
+#include "guichan/text.hpp"
+#include "guichan/textinput.hpp"
+#include "guichan/textlistener.hpp"
 #include "guichan/widget.hpp"
 
 #include <algorithm>
@@ -142,6 +145,7 @@ namespace gcn
             mInput->_pollInput();
 
             handleKeyInput();
+            handleTextInput();
             handleMouseInput();
         }
 
@@ -282,6 +286,32 @@ namespace gcn
                 keyEventConsumed = keyEvent.isConsumed();
             }
 
+            // A back end without native text input never fills the text
+            // queue, so derive the entered text from a character key that
+            // no key listener acted on. Tab and keys pressed together with
+            // control, alt or meta are shortcuts rather than text.
+            if (!keyEventConsumed
+                && !mInput->hasTextInput()
+                && keyInput.getType() == KeyInput::Pressed
+                && keyInput.getKey().isCharacter()
+                && keyInput.getKey().getValue() != Key::Tab
+                && !mControlPressed
+                && !mAltPressed
+                && !mMetaPressed
+                && mFocusHandler->getFocused() != NULL)
+            {
+                Widget* source = getKeyEventSource();
+                TextEvent textEvent(source,
+                                    source,
+                                    mShiftPressed,
+                                    mControlPressed,
+                                    mAltPressed,
+                                    mMetaPressed,
+                                    Text::encodeUtf8(keyInput.getKey().getValue()));
+
+                distributeTextEvent(textEvent);
+            }
+
             // If the key event hasn't been consumed and
             // tabbing is enable check for tab press and
             // change focus.
@@ -295,6 +325,34 @@ namespace gcn
                 else
                     mFocusHandler->tabNext();
             }                           
+        }
+    }
+
+    void Gui::handleTextInput()
+    {
+        while (!mInput->isTextQueueEmpty())
+        {
+            TextInput textInput = mInput->dequeueTextInput();
+
+            if (mFocusHandler->getFocused() == NULL)
+                continue;
+
+            if (!mFocusHandler->getFocused()->isFocusable())
+            {
+                mFocusHandler->focusNone();
+                continue;
+            }
+
+            Widget* source = getKeyEventSource();
+            TextEvent textEvent(source,
+                                source,
+                                mShiftPressed,
+                                mControlPressed,
+                                mAltPressed,
+                                mMetaPressed,
+                                textInput.getText());
+
+            distributeTextEvent(textEvent);
         }
     }
 
@@ -746,6 +804,58 @@ namespace gcn
             // If a non modal focused widget has been reach
             // and we have modal focus cancel the distribution.
             if (mFocusHandler->getModalFocused() != NULL
+                && !widget->isModalFocused())
+                break;
+        }
+    }
+
+    void Gui::distributeTextEvent(TextEvent& textEvent)
+    {
+        Widget* parent = textEvent.getSource();
+        Widget* widget = textEvent.getSource();
+
+        if (mFocusHandler->getModalFocused() != NULL
+            && !widget->isModalFocused())
+            return;
+
+        if (mFocusHandler->getModalMouseInputFocused() != NULL
+            && !widget->isModalMouseInputFocused())
+            return;
+
+        while (parent != NULL)
+        {
+            // If the widget has been removed due to input
+            // cancel the distribution.
+            if (!Widget::widgetExists(widget))
+                break;
+
+            parent = widget->getParent();
+
+            if (widget->isEnabled())
+            {
+                textEvent.mDistributor = widget;
+                std::list<TextListener*> textListeners = widget->_getTextListeners();
+
+                // Send the event to all text listeners of the source widget.
+                for (std::list<TextListener*>::iterator it = textListeners.begin();
+                     it != textListeners.end();
+                     ++it)
+                {
+                    (*it)->textInput(textEvent);
+                }
+            }
+
+            if (textEvent.isConsumed())
+                break;
+
+            Widget* swap = widget;
+            widget = parent;
+            parent = swap->getParent();
+
+            // If a non modal focused widget has been reach
+            // and we have modal focus cancel the distribution.
+            if (mFocusHandler->getModalFocused() != NULL
+                && widget != NULL
                 && !widget->isModalFocused())
                 break;
         }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1,0 +1,69 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * For comments regarding functions please see the header file.
+ */
+
+#include "guichan/input.hpp"
+
+#include "guichan/exception.hpp"
+#include "guichan/textinput.hpp"
+
+namespace gcn
+{
+    bool Input::hasTextInput()
+    {
+        return false;
+    }
+
+    bool Input::isTextQueueEmpty()
+    {
+        return true;
+    }
+
+    TextInput Input::dequeueTextInput()
+    {
+        throw GCN_EXCEPTION("The queue is empty.");
+    }
+}

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -62,43 +62,39 @@ namespace gcn
         {
             return (c & 0xC0) == 0x80;
         }
+    }
 
-        /**
-         * Encodes a Unicode code point as UTF-8. Values outside of the
-         * range 0 to 0x10FFFF result in an empty string.
-         */
-        std::string encodeUtf8(int character)
-        {
-            std::string result;
+    std::string Text::encodeUtf8(int character)
+    {
+        std::string result;
 
-            if (character < 0)
-                return result;
-
-            if (character < 0x80)
-            {
-                result += (char)character;
-            }
-            else if (character < 0x800)
-            {
-                result += (char)(0xC0 | (character >> 6));
-                result += (char)(0x80 | (character & 0x3F));
-            }
-            else if (character < 0x10000)
-            {
-                result += (char)(0xE0 | (character >> 12));
-                result += (char)(0x80 | ((character >> 6) & 0x3F));
-                result += (char)(0x80 | (character & 0x3F));
-            }
-            else if (character <= 0x10FFFF)
-            {
-                result += (char)(0xF0 | (character >> 18));
-                result += (char)(0x80 | ((character >> 12) & 0x3F));
-                result += (char)(0x80 | ((character >> 6) & 0x3F));
-                result += (char)(0x80 | (character & 0x3F));
-            }
-
+        if (character < 0)
             return result;
+
+        if (character < 0x80)
+        {
+            result += (char)character;
         }
+        else if (character < 0x800)
+        {
+            result += (char)(0xC0 | (character >> 6));
+            result += (char)(0x80 | (character & 0x3F));
+        }
+        else if (character < 0x10000)
+        {
+            result += (char)(0xE0 | (character >> 12));
+            result += (char)(0x80 | ((character >> 6) & 0x3F));
+            result += (char)(0x80 | (character & 0x3F));
+        }
+        else if (character <= 0x10FFFF)
+        {
+            result += (char)(0xF0 | (character >> 18));
+            result += (char)(0x80 | ((character >> 12) & 0x3F));
+            result += (char)(0x80 | ((character >> 6) & 0x3F));
+            result += (char)(0x80 | (character & 0x3F));
+        }
+
+        return result;
     }
 
     Text::Text()

--- a/src/textevent.cpp
+++ b/src/textevent.cpp
@@ -1,0 +1,79 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * For comments regarding functions please see the header file.
+ */
+
+#include "guichan/textevent.hpp"
+
+namespace gcn
+{
+    TextEvent::TextEvent(Widget* source,
+                         Widget* distributor,
+                         bool isShiftPressed,
+                         bool isControlPressed,
+                         bool isAltPressed,
+                         bool isMetaPressed,
+                         const std::string& text)
+            :InputEvent(source,
+                        distributor,
+                        isShiftPressed,
+                        isControlPressed,
+                        isAltPressed,
+                        isMetaPressed),
+             mText(text)
+    {
+
+    }
+
+    TextEvent::~TextEvent()
+    {
+
+    }
+
+    const std::string& TextEvent::getText() const
+    {
+        return mText;
+    }
+}

--- a/src/textinput.cpp
+++ b/src/textinput.cpp
@@ -1,0 +1,67 @@
+/*      _______   __   __   __   ______   __   __   _______   __   __
+ *     / _____/\ / /\ / /\ / /\ / ____/\ / /\ / /\ / ___  /\ /  |\/ /\
+ *    / /\____\// / // / // / // /\___\// /_// / // /\_/ / // , |/ / /
+ *   / / /__   / / // / // / // / /    / ___  / // ___  / // /| ' / /
+ *  / /_// /\ / /_// / // / // /_/_   / / // / // /\_/ / // / |  / /
+ * /______/ //______/ //_/ //_____/\ /_/ //_/ //_/ //_/ //_/ /|_/ /
+ * \______\/ \______\/ \_\/ \_____\/ \_\/ \_\/ \_\/ \_\/ \_\/ \_\/
+ *
+ * Copyright (c) 2004 - 2008 Olof Naessén and Per Larsson
+ *
+ *
+ * Per Larsson a.k.a finalman
+ * Olof Naessén a.k.a jansem/yakslem
+ *
+ * Visit: http://guichan.sourceforge.net
+ *
+ * License: (BSD)
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of Guichan nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * For comments regarding functions please see the header file.
+ */
+
+#include "guichan/textinput.hpp"
+
+namespace gcn
+{
+    TextInput::TextInput(const std::string& text)
+            :mText(text)
+    {
+
+    }
+
+    void TextInput::setText(const std::string& text)
+    {
+        mText = text;
+    }
+
+    const std::string& TextInput::getText() const
+    {
+        return mText;
+    }
+}

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -57,6 +57,7 @@
 #include "guichan/graphics.hpp"
 #include "guichan/keyinput.hpp"
 #include "guichan/keylistener.hpp"
+#include "guichan/textlistener.hpp"
 #include "guichan/mouseinput.hpp"
 #include "guichan/mouselistener.hpp"
 #include "guichan/widgetlistener.hpp"
@@ -421,6 +422,16 @@ namespace gcn
         mKeyListeners.remove(keyListener);
     }
 
+    void Widget::addTextListener(TextListener* textListener)
+    {
+        mTextListeners.push_back(textListener);
+    }
+
+    void Widget::removeTextListener(TextListener* textListener)
+    {
+        mTextListeners.remove(textListener);
+    }
+
     void Widget::addFocusListener(FocusListener* focusListener)
     {
         mFocusListeners.push_back(focusListener);
@@ -640,6 +651,11 @@ namespace gcn
     const std::list<KeyListener*>& Widget::_getKeyListeners()
     {
         return mKeyListeners;
+    }
+
+    const std::list<TextListener*>& Widget::_getTextListeners()
+    {
+        return mTextListeners;
     }
 
     const std::list<FocusListener*>& Widget::_getFocusListeners()

--- a/src/widgets/textbox.cpp
+++ b/src/widgets/textbox.cpp
@@ -63,6 +63,7 @@ namespace gcn
 
         addMouseListener(this);
         addKeyListener(this);
+        addTextListener(this);
         adjustSize();
     }
 
@@ -75,6 +76,7 @@ namespace gcn
 
         addMouseListener(this);
         addKeyListener(this);
+        addTextListener(this);
         adjustSize();
     }
 
@@ -186,13 +188,21 @@ namespace gcn
         else if(key.getValue() == Key::Tab)
             insertText("    ");
 
-        else if (key.isCharacter() && mEditable)
-            mText.insert(key.getValue());
+        // Any other key is left alone: entered text arrives through
+        // textInput and unhandled keys may be meant for a parent.
+        else
+            return;
 
         adjustSize();
         scrollToCaret();
 
         keyEvent.consume();
+    }
+
+    void TextBox::textInput(TextEvent& textEvent)
+    {
+        insertText(textEvent.getText());
+        textEvent.consume();
     }
 
     void TextBox::adjustSize()

--- a/src/widgets/textfield.cpp
+++ b/src/widgets/textfield.cpp
@@ -63,6 +63,7 @@ namespace gcn
 
         addMouseListener(this);
         addKeyListener(this);
+        addTextListener(this);
     }
 
     TextField::TextField(const std::string& text):
@@ -76,6 +77,7 @@ namespace gcn
 
         addMouseListener(this);
         addKeyListener(this);
+        addTextListener(this);
     }
 
     void TextField::setText(const std::string& text)
@@ -215,15 +217,19 @@ namespace gcn
         else if (key.getValue() == Key::End)
             mText.setCaretColumn(mText.getNumberOfColumns(0));
 
-        else if (key.isCharacter()
-                 && key.getValue() != Key::Tab
-                 && mEditable)
-            mText.insert(key.getValue());
+        // Any other key is left alone: entered text arrives through
+        // textInput and unhandled keys may be meant for a parent.
+        else
+            return;
 
-        if (key.getValue() != Key::Tab)
-            keyEvent.consume();
-
+        keyEvent.consume();
         fixScroll();
+    }
+
+    void TextField::textInput(TextEvent& textEvent)
+    {
+        insertText(textEvent.getText());
+        textEvent.consume();
     }
 
     void TextField::adjustSize()


### PR DESCRIPTION
Stacked on #26 (`text-utf8`). Gives Guichan first-class text input events so back ends that report entered text as UTF-8 strings (SDL2's `SDL_TEXTINPUT`, input methods) no longer have to go through key events, and so keyboard shortcuts like Ctrl+V stop typing a `v` into text widgets.

New API:

- `gcn::TextInput`: queued item holding a UTF-8 `std::string` (`getText()`, `setText()`).
- `gcn::TextEvent : InputEvent` with `getText()`, constructed like `KeyEvent`.
- `gcn::TextListener` with `virtual void textInput(TextEvent&)`.
- `Widget::addTextListener()`, `removeTextListener()`, protected `_getTextListeners()`.
- `Input::hasTextInput()` (default false), `isTextQueueEmpty()` (default true) and `dequeueTextInput()` (default throws). Non-pure, so existing back ends compile unchanged.
- `Gui::handleTextInput()` drains the text queue and `distributeTextEvent()` bubbles the event from the focused widget up the parent chain until consumed.
- `Text::encodeUtf8(int)` is now a public static helper.
- `TextField` and `TextBox` implement `TextListener` and insert text only through `textInput()`. `keyPressed()` handles and consumes only the editing and caret keys.

Synthesis rule for back ends without native text input (`hasTextInput()` false): after a pressed key has been offered to the global key listeners and the focused widget, `handleKeyInput()` distributes a text event with the UTF-8 encoding of the key value when the key event was not consumed, `Key::isCharacter()` holds, the value is not `Key::Tab`, and none of control, alt or meta is held. Back ends with native text input set `hasTextInput()` true, deliver whole strings through the text queue, and get no synthesis.
