### PR TITLE
Hold the widget instances in a set rather than a list

### DIFF
--- a/include/guichan/widget.hpp
+++ b/include/guichan/widget.hpp
@@ -45,6 +45,7 @@
 #define GCN_WIDGET_HPP
 
 #include <list>
+#include <set>
 #include <string>
 
 #include "guichan/color.hpp"
@@ -1266,9 +1267,11 @@ namespace gcn
         static Font* mGlobalFont;
 
         /**
-         * Holds a list of all instances of widgets.
+         * Holds all instances of widgets. A set rather than a list, so that
+         * widgetExists and the removal in the destructor do not have to scan
+         * every widget in the application.
          */
-        static std::list<Widget*> mWidgetInstances;
+        static std::set<Widget*> mWidgetInstances;
 
         /**
          * Holds all children of the widget.

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -67,7 +67,7 @@ namespace gcn
 {
     Font* Widget::mGlobalFont = NULL;
     DefaultFont Widget::mDefaultFont;
-    std::list<Widget*> Widget::mWidgetInstances;
+    std::set<Widget*> Widget::mWidgetInstances;
 
     Widget::Widget()
             : mForegroundColor(0x000000),
@@ -85,7 +85,7 @@ namespace gcn
               mEnabled(true),
               mCurrentFont(NULL)
     {
-        mWidgetInstances.push_back(this);
+        mWidgetInstances.insert(this);
     }
 
     Widget::~Widget()
@@ -106,7 +106,7 @@ namespace gcn
 
         _setFocusHandler(NULL);
 
-        mWidgetInstances.remove(this);
+        mWidgetInstances.erase(this);
     }
 
     void Widget::drawFrame(Graphics* graphics)
@@ -486,7 +486,7 @@ namespace gcn
     {
         mGlobalFont = font;
 
-        std::list<Widget*>::iterator iter;
+        std::set<Widget*>::const_iterator iter;
         for (iter = mWidgetInstances.begin(); iter != mWidgetInstances.end(); ++iter)
         {
             if ((*iter)->mCurrentFont == NULL)
@@ -502,14 +502,9 @@ namespace gcn
 
     bool Widget::widgetExists(const Widget* widget)
     {
-        std::list<Widget*>::const_iterator iter;
-        for (iter = mWidgetInstances.begin(); iter != mWidgetInstances.end(); ++iter)
-        {
-            if (*iter == widget)
-                return true;
-        }
-
-        return false;
+        // The cast is safe as the widget is only used to look up a pointer.
+        return mWidgetInstances.find(const_cast<Widget*>(widget))
+                != mWidgetInstances.end();
     }
 
     bool Widget::isTabInEnabled() const


### PR DESCRIPTION
Follows up on a review comment on #19: `Widget::widgetExists` iterates every widget instance, so should `mWidgetInstances` be a set?

Yes, and the case is stronger than it looks, because the removal in `~Widget` scans the list too: `std::list::remove` is linear. Tearing down a GUI is therefore quadratic in the number of widgets today, independently of anything on the event path.

Measured with 5000 widgets, release build, 100k `widgetExists` calls:

| | list | set |
| --- | --- | --- |
| create 5000 widgets | 1.34 ms | 1.59 ms |
| destroy 5000 widgets | 24.32 ms | 0.43 ms |
| widgetExists, first widget created | 0.22 ms | 0.84 ms |
| widgetExists, last widget created | 1000.23 ms | 2.01 ms |
| widgetExists, deleted widget | 999.75 ms | 2.09 ms |

The list only wins when the widget being looked up happens to be the first one ever created, which is the front of the list. For any other widget, or for one that is gone, it is hundreds of times slower. Creation gets 19% slower in exchange, which is 0.25 ms across 5000 widgets.

The only visible change is that `setGlobalFont` now visits widgets in pointer order rather than creation order. That loop only asks each widget to recalculate on a font change, so the order carries no meaning.

Behaviour is otherwise identical: `widgetExists` returns the same answers before and after for a live stack widget, a live heap widget, a deleted widget, a null pointer, a const pointer, and a child removed from its parent but not deleted.
